### PR TITLE
Establish a reproducible, experiment-ready ROS 2 baseline

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -22,8 +22,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       sudo \
       ros-jazzy-foxglove-bridge \
       ros-jazzy-joint-state-publisher \
+      ros-jazzy-nav-msgs \
       ros-jazzy-robot-state-publisher \
       ros-jazzy-rviz2 \
+      ros-jazzy-std-msgs \
       ros-jazzy-xacro \
     && rm -rf /var/lib/apt/lists/*
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       ros-jazzy-joint-state-publisher \
       ros-jazzy-nav-msgs \
       ros-jazzy-robot-state-publisher \
+      ros-jazzy-rosgraph-msgs \
       ros-jazzy-rviz2 \
       ros-jazzy-std-msgs \
       ros-jazzy-xacro \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,10 +1,44 @@
-FROM mostafah04/mobile_robot:latest
+FROM ros:jazzy-ros-base-noble@sha256:567b81bc54f44479e16ef1b75e4984d132f154b6511ea4fc851ee6bde76c30f8
 
-RUN sudo apt install software-properties-common 
-RUN sudo add-apt-repository universe
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-RUN sudo apt install ros-humble-xacro -y && \
-  sudo apt install ros-humble-joint-state-publisher -y && \
-  sudo apt install pip -y
+ARG USERNAME=ubuntu
 
-RUN pip install pybullet && pip install numpy==1.23
+ENV DEBIAN_FRONTEND=noninteractive \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    ROS_DISTRO=jazzy \
+    VIRTUAL_ENV=/opt/robot-dog-venv
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      build-essential \
+      git \
+      make \
+      python3-colcon-common-extensions \
+      python3-pip \
+      python3-rosdep \
+      python3-scipy \
+      python3-venv \
+      sudo \
+      ros-jazzy-foxglove-bridge \
+      ros-jazzy-joint-state-publisher \
+      ros-jazzy-robot-state-publisher \
+      ros-jazzy-rviz2 \
+      ros-jazzy-xacro \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN echo "${USERNAME} ALL=(root) NOPASSWD:ALL" > "/etc/sudoers.d/${USERNAME}" \
+    && chmod 0440 "/etc/sudoers.d/${USERNAME}"
+
+COPY requirements.txt /tmp/robot-dog-requirements.txt
+
+RUN python3 -m venv --system-site-packages "${VIRTUAL_ENV}" \
+    && "${VIRTUAL_ENV}/bin/python" -m pip install --no-cache-dir --upgrade pip==25.1.1 \
+    && "${VIRTUAL_ENV}/bin/python" -m pip install --no-cache-dir -r /tmp/robot-dog-requirements.txt
+
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
+
+USER ${USERNAME}
+WORKDIR /workspaces/robot-dog
+
+RUN echo 'source /opt/ros/jazzy/setup.bash' >> "/home/${USERNAME}/.bashrc"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,3 +1,32 @@
 {
-    "build":{"dockerfile": "Dockerfile"}
+  "name": "Robot Dog — ROS 2 Jazzy",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": "..",
+    "args": {
+      "USERNAME": "ubuntu"
+    }
+  },
+  "remoteUser": "ubuntu",
+  "updateRemoteUserUID": true,
+  "workspaceFolder": "/workspaces/robot-dog",
+  "forwardPorts": [8765],
+  "portsAttributes": {
+    "8765": {
+      "label": "Foxglove Bridge",
+      "onAutoForward": "silent"
+    }
+  },
+  "containerEnv": {
+    "ROS_DISTRO": "jazzy"
+  },
+  "postCreateCommand": "make build",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-iot.vscode-ros",
+        "ms-python.python"
+      ]
+    }
+  }
 }

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+**
+!requirements.txt

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto eol=lf
+*.stl binary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: ROS 2 baseline
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  build-test-smoke:
+    runs-on: ubuntu-24.04
+    container:
+      image: ros:jazzy-ros-base-noble@sha256:567b81bc54f44479e16ef1b75e4984d132f154b6511ea4fc851ee6bde76c30f8
+    env:
+      ROS_DISTRO: jazzy
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Install bootstrap tools
+        run: |
+          apt-get update
+          apt-get install --yes --no-install-recommends \
+            build-essential \
+            make \
+            python3-colcon-common-extensions \
+            python3-pip \
+            python3-rosdep \
+            python3-venv
+          rm -rf /var/lib/apt/lists/*
+
+      - name: Install dependencies
+        run: make setup
+
+      - name: Build workspace
+        run: make build
+
+      - name: Run tests
+        run: make test
+
+      - name: Smoke-test headless simulation
+        run: make smoke
+
+      - name: Upload ROS logs on failure
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ros-logs
+          path: robot_ws/log
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 .pio
+.venv/
+.pytest_cache/
+.ruff_cache/
 .vscode/.browse.c_cpp.db*
 .vscode/c_cpp_properties.json
 .vscode/launch.json
@@ -7,3 +10,4 @@ build/
 install/
 log/
 *.pyc
+__pycache__/

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ export ROS_DISTRO
 
 .DEFAULT_GOAL := help
 
-.PHONY: help setup build test sim smoke
+.PHONY: help setup build test sim experiment smoke
 
 help:
 	@echo "Robot Dog developer commands"
@@ -13,7 +13,8 @@ help:
 	@echo "  make build   Build the ROS 2 workspace with symlink installs"
 	@echo "  make test    Run all package tests and print the result summary"
 	@echo "  make sim     Start the PyBullet simulation and Foxglove bridge"
-	@echo "  make smoke   Verify the headless simulation publishes ROS topics"
+	@echo "  make experiment  Run the example controller and sensor teaching slice"
+	@echo "  make smoke   Verify commands and simulated sensor topics end to end"
 	@echo
 	@echo "Override ROS_DISTRO when needed, for example: ROS_DISTRO=humble make build"
 
@@ -28,6 +29,9 @@ test:
 
 sim:
 	./scripts/sim.sh $(SIM_ARGS)
+
+experiment:
+	./scripts/experiment.sh $(SIM_ARGS)
 
 smoke:
 	./scripts/smoke_sim.sh

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+SHELL := /bin/bash
+
+ROS_DISTRO ?= jazzy
+export ROS_DISTRO
+
+.DEFAULT_GOAL := help
+
+.PHONY: help setup build test sim smoke
+
+help:
+	@echo "Robot Dog developer commands"
+	@echo "  make setup   Install package and pinned Python dependencies"
+	@echo "  make build   Build the ROS 2 workspace with symlink installs"
+	@echo "  make test    Run all package tests and print the result summary"
+	@echo "  make sim     Start the PyBullet simulation and Foxglove bridge"
+	@echo "  make smoke   Verify the headless simulation publishes ROS topics"
+	@echo
+	@echo "Override ROS_DISTRO when needed, for example: ROS_DISTRO=humble make build"
+
+setup:
+	./scripts/bootstrap.sh
+
+build:
+	./scripts/build.sh
+
+test:
+	./scripts/test.sh
+
+sim:
+	./scripts/sim.sh $(SIM_ARGS)
+
+smoke:
+	./scripts/smoke_sim.sh

--- a/README.md
+++ b/README.md
@@ -1,110 +1,132 @@
 # Robot Dog
 
-Welcome to the Robot Dog project! This repository contains the codebase for controlling a custom-built robot dog designed for autonomous indoor navigation. Our primary development focus is under `robot_ws`, which involves creating ROS2 packages for operating the robot dog.
+Robot Dog is a ROS 2 learning project built around a custom quadruped. The repository currently contains a simplified robot description, a headless PyBullet proof-of-concept, and a basic inverse-kinematics command adapter. It is being revived as an environment for learning robot control, navigation, state estimation, and robot learning.
 
-While the physical robot dog exists, we are currently developing a virtual model to test control algorithms and methodologies before deploying them on the real robot. In parallel, we're designing a custom controller board featuring a powerful STM32 MCU, an IMU, and more.
+This baseline targets **ROS 2 Jazzy on Ubuntu 24.04**. The previous project used ROS 2 Humble; Humble may still work, but it is not the reproducible target used by CI.
 
-## Table of Contents
+## Current status
 
-- [Running the Robot Simulation Locally](#running-the-robot-simulation-locally)
-- [Software Progress](#software-progress)
-  - [Simulation](#simulation)
-  - [Control](#control)
-- [Hardware Progress](#hardware-progress)
-- [Mechanical Progress](#mechanical-progress)
-- [Contributing](#contributing)
-- [Repo Maintainers](#repo-maintainers)
+| Area | Status |
+| --- | --- |
+| Development environment | Reproducible ROS 2 Jazzy devcontainer and pinned Python dependencies |
+| Robot description | Simplified open-chain Xacro/URDF with 12 actuated joints |
+| Simulation | Headless PyBullet node publishing `/joint_states` and `world -> base_link` TF |
+| Control | Basic per-leg IK and conversion from the physical closed-chain geometry to simplified simulated joints |
+| Visualization | Robot state publisher, optional RViz, and a Foxglove bridge on port `8765` |
+| Tests | ROS package lint plus an end-to-end headless launch smoke test |
+| MuJoCo | Not implemented yet; planned as the next simulator vertical slice |
+| Sensors, estimation, navigation, learning | Not implemented |
+| Hardware and firmware | Not present in this repository |
 
-## Running the Robot Simulation Locally
+The existing simulation is a development checkpoint, not a validated model of the physical robot. It has no simulated sensors, environment API, controller benchmarks, or dynamics validation yet.
 
-*Detailed instructions coming soon!*
+## Quick start
 
-## Software Progress
-### Simulation
-To faciltate software development without risking damage to the robot dog we decided to attempt to simulate the physical robot to some degree to de-risk development and make it faster + easier.
+The supported path is the included devcontainer. It pins the ROS base image and Python runtime dependencies and avoids depending on the workstation's ROS installation.
 
-#### Matplotlib Model
-To begin, an effort was made to create a simple stick figure like model of the robot dog to facilitate developing the IK for individual legs before testing on the physical dog. This model was directly based
-on measurements from the dog assembly (in Fusion360) and offered a "quick and dirty" way to verify that the IK looks about right. 
+1. Install Docker and a devcontainer-compatible editor or CLI.
+2. Clone this repository and open it in the devcontainer.
+3. Build, test, and smoke-test the existing simulator:
 
-As this model was developed further and the lower level firmware for joint control was established, we began to test and verify this stick figure model along with the IK. These tests involved commanding 
-certain leg joint commands and comparing the resulting final leg configuration in real life and the Matplotlib model. These tests allowed us to uncover obvious mistakes
-in the IK model and iterate on it until it was fixed. 
+   ```bash
+   make build
+   make test
+   make smoke
+   ```
 
-![image](https://github.com/user-attachments/assets/9e5253ad-311c-4a26-8528-d4dc2fbd1065)
+4. Start the simulator and Foxglove bridge:
 
-The model was expanded to involve the full robot body and was used to visualize simple gait sequences genearted using time sinusoidal functions mapped to the x and z positions of the ends of each leg. This
-led us to getting a video of the dog taking its first steps 🎉! 
+   ```bash
+   make sim
+   ```
 
-![ezgif-7-b41cf989ee](https://github.com/user-attachments/assets/2a597be4-6f1a-4240-a477-af5c312f57ea)
-</br>Clumsy... but we all start somewhere 😅.
+The devcontainer runs `make build` after creation. Stop a running launch with `Ctrl-C`.
 
-#### Gazebo + ROS2
-To simplify development and ensure modularity between simulation + testing and physical robot we wanted to use the ROS framework for development, specifically ROS2 (Humble). We found that commonly the general
-public seems to use gazebo for ROS2 related projects and thus decided to try it out hoping that there would be enough documentation and support out there (foreshadowing 🥲).
+### Native ROS installation
 
-The problem began with having to generate URDF model based on our robot dog. Since our robot was fully designed in Fusion360 we were able to use an open source conversion tool (Fusion2URDF). However, we ran
-into a major issue. Due to URDF's tree structure (enforcing a single parent per link) and since our robot used a closed chain design for the leg, we had to find a work-around. After much research, we found that
-it would be possible to create essentially generate a URDF model with the leg kinematic chain open then close it using custom software. This was the ideal case as we wanted to be able to check for collisions 
-across the entire leg assembly as well as maintain the dynamic properties as much as possible. However, this solution would have involved a lot of work to retrieve the correct relative transforms in fusion
-(numbers were not very nice), so we decided to proceed with an initial simplified open chain model for the legs and create a mapper in software that uses the FK of the leg servo joint angles to command the
-simulated leg joint angles. We still aim to revist using the open chain model and closing it in softwar in the future as that would provide a better representation of the physical system.
+On a machine with ROS 2 Jazzy already installed:
 
-![image (1)](https://github.com/user-attachments/assets/81aa5075-6eb8-4f04-8016-077017ab4275)
-</br>Our closed chain 3DOF leg assembly.
+```bash
+make setup
+make build
+make test
+make smoke
+make sim
+```
 
-![image](https://github.com/user-attachments/assets/b28d3f52-7aac-47ef-b686-1f328761c2e6)
-</br>Open chain robot dog assembly to be closed in software.
+`make setup` installs dependencies declared by the ROS packages and creates `.venv` with the pinned packages from `requirements.txt`. It does not install ROS itself.
 
-![image](https://github.com/user-attachments/assets/90abb5cf-f6da-44d5-989f-92a68b089e0a)
-</br> Simplified robot dog assembly (in use)
+## Remote visualization
 
-With the URDF model we were able to begin using gazebo for a physics based simulation of our robot dog. After hours of debugging, tuning parameters and correcting the inertia tensors we were able to 
-get the robot standing in gazebo. The next step was controlling the dog. For this step we opted for ros2-control as we had seen demonstrations of quadrupeds using ros-control (using ROS1), 
-but we were very wrong 💀.
+PyBullet runs headlessly. The normal remote-workstation workflow is to render in Foxglove on your local machine:
 
-After more hours trying to control the robot using different built-in controllers for ros2-control, turns out, ROS2 control doesn't seem to behave nicely for legged robots (skids and builds up acceleration)...
-Who would have thought...
+1. Run `make sim` on the workstation.
+2. Forward TCP port `8765`. VS Code forwards it automatically from the devcontainer, or use SSH:
 
-Left with either writing our own controller for the dog in gazebo, which probably would have been to bad looking back at this, but we had finals coming up in just a few weeks at this point and we just wanted to get this done (Calc 3 is not it btw...). Soooo, we decided to redo everything and write our own physics engine from scratch!!!
+   ```bash
+   ssh -L 8765:localhost:8765 USER@REMOTE_HOST
+   ```
 
-![This-is-Fine-300x300](https://github.com/user-attachments/assets/330ddcf8-a036-4f90-bf46-c5fb8c103560)
+3. Open the Foxglove desktop or web application locally and connect to `ws://localhost:8765`.
 
-Just kidding. We just decided to use PyBullet instead. It was mainly just much easier to get setup with our URDF model.
+RViz is disabled by default because it requires a graphical display. On a machine with a working display, start it with:
 
-#### PyBullet
-PyBullet is pretty straightforward and easy to use which made it really easy to just setup a ROS2 node that spins up a PyBullet instance with a simple world and the dog along with subscribers and publishers
-for the joint commands and the robot's state.
+```bash
+make sim SIM_ARGS="use_rviz:=true use_foxglove:=false"
+```
 
-At this point we were able to setup launch files and visualization in rviz/foxglove (either is possible currently using foxglove... just felt like it lol...).
+## Developer commands
 
-Then we just setup a quick control node that carries out IK and FK to determine the URDF model's joint angles based on the servo commanded joint angles to mimic the physical hardware interface as much as possible.
+| Command | Purpose |
+| --- | --- |
+| `make setup` | Resolve ROS dependencies and install pinned Python dependencies |
+| `make build` | Build `robot_ws` using a symlink install |
+| `make test` | Run all package tests and print the complete result summary |
+| `make smoke` | Launch the stack headlessly and verify `/joint_states` and `/tf` |
+| `make sim` | Launch PyBullet, the joint controller, robot state publisher, and Foxglove |
 
-Now we can just test control related work atm and working on getting a few virtual sensors in place starting with IMUs to begin working on the localization and navigation stack.
+All commands accept a different installed ROS distribution through `ROS_DISTRO`, for example `ROS_DISTRO=humble make build`. Jazzy remains the tested target.
 
-![27d](https://github.com/user-attachments/assets/a28fa524-6821-42e2-90c6-51e77854569a)
+## Repository layout
 
-### Controls
-Really the goals for this project in terms of control is somewhat limitless (not considering that we are eng students and are too broke to use top of the line hardware). We can really go super simple with 
-pre-defined gait sequences or even close loop stabilized gait sequences, or really push our limits and try to implement some cool paper proposing some hybrid MPC + RL approach. Overall, the main goal for
-controls is to make the software interface modular enough to allow for any sort of control. Which should be ideally fullfilled by our use of ROS2 nodes to modularize different components of the software.
+```text
+.
+├── .devcontainer/       # Pinned ROS 2 Jazzy development image
+├── .github/workflows/   # Build, test, and simulation smoke CI
+├── foxglove_config/     # Existing Foxglove layout
+├── robot_ws/src/
+│   ├── robot_controller # Leg kinematics and ROS command adapter
+│   ├── robot_desc       # Simplified Xacro/URDF and visualization launch
+│   └── robot_simulation # Headless PyBullet simulator and top-level launch
+├── scripts/             # Reusable setup/build/test/run entry points
+├── Makefile
+└── requirements.txt
+```
 
-#### Un-stablized gaits
-##### Walk
-Essentially one leg is lifted at a time while all other legs move backwards (while in contact with the ground) moving the robot forward.
-</br>![ezgif-4-aa80b01d10](https://github.com/user-attachments/assets/c1ba8b27-beb9-4015-b9ff-c5e5d7f72cbc)
+## Robot-description history
 
-##### Trot
-Diagonal legs are locked in phase and the diagonal pair of legs are out of phase by half a period. This creates an almost jogging motion for the quadruped. Really nice for speed!
-</br>![ezgif-3-2344fa2f68](https://github.com/user-attachments/assets/b03eeeec-7a5d-4894-8521-3b7b8527fe43)
+The physical leg uses a closed kinematic chain, which URDF cannot represent directly because URDF requires a tree. The active description therefore uses a simplified three-joint serial leg and software maps the physical joint geometry to it.
 
-### Hardware Progress
+An older, more detailed open-chain export of the mechanism exists in Git history, but it is not part of the runnable baseline and the loop-closure constraints were never completed. The planned MuJoCo work should recover that description deliberately, reduce the very dense CAD meshes, and represent the missing loop closures with MuJoCo equality constraints while retaining a simplified URDF for ROS tooling.
 
-### Mechanical Progress
+## Revival roadmap
 
-## Repo Maintainers
+1. **Reproducible baseline** — repeatable environment, declared dependencies, CI, and a verified PyBullet launch. This repository state covers that phase.
+2. **MuJoCo vertical slice** — load one canonical model, step deterministically, apply joint commands, publish state, and render offscreen.
+3. **Model fidelity** — recover the detailed mechanism, add loop-closure constraints, simplify collision geometry, and validate mass/inertia/joint conventions.
+4. **Robotics interfaces** — sensors, state-estimation exercises, navigation interfaces, and controller benchmarks.
+5. **Learning environment** — Gymnasium-style reset/step API, observations/actions/rewards, reproducible experiments, and ROS adapters at the boundary.
 
-- **Mostafa Hussein**: [LinkedIn](https://www.linkedin.com/in/mostafa-hussein-04/)
-- **Vinesh Vivekanand**: [LinkedIn](https://www.linkedin.com/in/vinesh-vivekanand/)
-- **Armaan Rasheed**: [LinkedIn](https://www.linkedin.com/in/armaan-rasheed-530229a0/)
+## Project history
 
+The original project progressed from a Matplotlib stick model to simple walking and trotting experiments on the physical robot, then explored Gazebo and `ros2_control` before moving to PyBullet. The current code captures only a portion of that work: the simplified robot model, basic leg IK, and the initial ROS/PyBullet bridge.
+
+Maintainers listed by the original project:
+
+- [Mostafa Hussein](https://www.linkedin.com/in/mostafa-hussein-04/)
+- [Vinesh Vivekanand](https://www.linkedin.com/in/vinesh-vivekanand/)
+- [Armaan Rasheed](https://www.linkedin.com/in/armaan-rasheed-530229a0/)
+
+## License
+
+No repository-level license is currently declared. Package metadata records this as `NOASSERTION`; do not assume permission to redistribute until the maintainers choose and add a license.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ make sim SIM_ARGS="use_rviz:=true use_foxglove:=false"
 | `make setup` | Resolve ROS dependencies and install pinned Python dependencies |
 | `make build` | Build `robot_ws` using a symlink install |
 | `make test` | Run all package tests and print the complete result summary |
-| `make smoke` | Verify commands, sensor topics, contact forces, and ground truth together |
+| `make smoke` | Verify simulation time, clean TF, commands, sensors, forces, and truth |
 | `make sim` | Launch PyBullet, the joint controller, robot state publisher, and Foxglove |
 | `make experiment` | Add the deterministic example controller and interface monitor |
 
@@ -98,6 +98,9 @@ The experiment launch is deliberately small. It is an interface for learning how
 flowchart LR
     example["Example stance controller"] -->|/control_inputs| adapter["Closed-chain command adapter"]
     adapter -->|/cmd_jnts| sim["Fixed-step PyBullet simulator"]
+    sim --> clock["/clock (exact 10 ms steps)"]
+    clock --> example
+    clock --> adapter
     sim --> sensors["/sim/sensors/* (mock/idealized)"]
     sim --> truth["/sim/ground_truth/odom"]
     sensors --> monitor["Example interface monitor"]
@@ -105,12 +108,13 @@ flowchart LR
     monitor -->|all command and sensor streams observed| ready["/sim/experiment/ready"]
 ```
 
-The example controller repeats a gentle, symmetric 4 mm stance-height cycle. It generates the same sample sequence every cycle and stays within the current adapter's configured joint limits. PyBullet advances with a fixed 10 ms physics step; ROS timers are not a hard real-time or lockstep scheduler.
+The example controller repeats a gentle, symmetric 4 mm stance-height cycle. It generates the same sample sequence every cycle and stays within the current adapter's configured joint limits. PyBullet advances with a fixed 10 ms physics step and publishes `/clock`; sensor and command headers use exact integer multiples of that step. Workstation scheduling can change the real-time factor, but not the published simulation timeline. This remains a teaching simulator, not a hard real-time system.
 
 ### Topic semantics
 
 | Topic | Type | Meaning |
 | --- | --- | --- |
+| `/clock` | `rosgraph_msgs/msg/Clock` | Step-derived simulation time, advanced exactly 10 ms after each PyBullet step. Experiment/controller/visualization nodes use `use_sim_time=true`; the simulator's wall timer stays independent so it can advance the clock. |
 | `/control_inputs` | `sensor_msgs/msg/JointState` | Physical closed-chain angles in radians. Numeric names `0..11` use leg order front-right, rear-right, rear-left, front-left, with three angles per leg. |
 | `/cmd_jnts` | `sensor_msgs/msg/JointState` | Adapter output addressed by explicit simplified-URDF joint names. |
 | `/sim/sensors/imu` | `sensor_msgs/msg/Imu` | Ideal orientation, body-frame angular velocity, and body-frame specific force at `base_link`; no noise, bias, saturation, or covariance model. |
@@ -118,14 +122,16 @@ The example controller repeats a gentle, symmetric 4 mm stance-height cycle. It 
 | `/sim/sensors/foot_contacts/<foot>` | `std_msgs/msg/Bool` | Binary plane contact for `front_left`, `front_right`, `rear_left`, or `rear_right`. |
 | `/sim/sensors/foot_contacts/<foot>/normal_force` | `std_msgs/msg/Float64` | Sum of PyBullet normal contact forces for that foot, in newtons. |
 | `/sim/sensors/foot_contacts/<foot>/wrench` | `geometry_msgs/msg/WrenchStamped` | Ideal PyBullet normal-plus-friction force in the corresponding foot-link frame, with torque about that link's origin. |
-| `/sim/ground_truth/odom` | `nav_msgs/msg/Odometry` | Exact simulated `world -> base_link` pose and body-frame twist. Keep this out of estimator inputs; use it for evaluation. |
-| `/sim/experiment/ready` | `std_msgs/msg/Bool` | The monitor has received every stream, command names match measured joint names, and at least one foot reports nonzero normal force. |
+| `/sim/ground_truth/odom` | `nav_msgs/msg/Odometry` | Exact `sim_ground_truth_world -> sim_ground_truth_base_link` pose and body-frame twist. These deliberately distinct frames keep truth out of the operational estimator tree. |
+| `/sim/experiment/ready` | `std_msgs/msg/Bool` | The monitor has received every stream, headers track the advancing step clock, command names match measured joints, and at least one foot reports nonzero normal force. |
 
 Contact and force values come directly from the simplified PyBullet collision model. They are mock simulation data, not a model of a load cell, force-sensitive resistor, or any real hardware sensor.
 
+The simulator does **not** publish exact truth as `world -> base_link` TF. The normal robot TF tree remains rooted at `base_link` for a future estimator to connect to `odom` or `map`. For visualization/debugging only, `make experiment SIM_ARGS="publish_ground_truth_tf:=true"` publishes the same truth pose in the isolated `sim_ground_truth_world -> sim_ground_truth_base_link` tree; it never claims the operational `base_link` frame.
+
 ### First learning exercise: contact-aided vertical velocity
 
-Create a new node that subscribes to the IMU, joint states, and four foot-contact/normal-force topics. Rotate IMU specific force into `world`, add gravity, and integrate vertical acceleration. When at least two feet have stable contact above a small force threshold, apply a zero-vertical-velocity update. Plot the estimate against `/sim/ground_truth/odom`, but never subscribe to ground truth inside the estimator itself. Then add configurable IMU bias/noise in your exercise node and observe how the contact update changes drift.
+Create a new node that subscribes to the IMU, joint states, and four foot-contact/normal-force topics. Rotate IMU specific force into your estimator's inertial frame, add gravity, and integrate vertical acceleration. When at least two feet have stable contact above a small force threshold, apply a zero-vertical-velocity update. Plot the estimate against `/sim/ground_truth/odom`, but never subscribe to ground truth inside the estimator itself. Then add configurable IMU bias/noise in your exercise node and observe how the contact update changes drift.
 
 This exercise teaches frame transforms, IMU conventions, contact gating, and evaluation separation. It is only a starting point for a contact-aided estimator; it does not account for slip, contact uncertainty, kinematic velocity constraints, or filter consistency.
 

--- a/README.md
+++ b/README.md
@@ -10,15 +10,15 @@ This baseline targets **ROS 2 Jazzy on Ubuntu 24.04**. The previous project used
 | --- | --- |
 | Development environment | Reproducible ROS 2 Jazzy devcontainer and pinned Python dependencies |
 | Robot description | Simplified open-chain Xacro/URDF with 12 actuated joints |
-| Simulation | Headless PyBullet node publishing `/joint_states` and `world -> base_link` TF |
-| Control | Basic per-leg IK and conversion from the physical closed-chain geometry to simplified simulated joints |
+| Simulation | Headless, fixed-step PyBullet node with idealized teaching sensors and separate ground truth |
+| Control | Per-leg IK plus a deterministic, gentle stance-height example controller |
 | Visualization | Robot state publisher, optional RViz, and a Foxglove bridge on port `8765` |
-| Tests | ROS package lint plus an end-to-end headless launch smoke test |
+| Tests | ROS package tests plus an end-to-end command/sensor headless smoke test |
 | MuJoCo | Not implemented yet; planned as the next simulator vertical slice |
-| Sensors, estimation, navigation, learning | Not implemented |
+| State estimation, navigation, learning | No estimator or environment yet; a PyBullet teaching interface is available |
 | Hardware and firmware | Not present in this repository |
 
-The existing simulation is a development checkpoint, not a validated model of the physical robot. It has no simulated sensors, environment API, controller benchmarks, or dynamics validation yet.
+The existing simulation is a development checkpoint, not a validated model of the physical robot. Its sensors are noise-free/mock PyBullet outputs, and it has no hardware sensor model, environment API, controller benchmarks, or dynamics validation yet.
 
 ## Quick start
 
@@ -37,8 +37,10 @@ The supported path is the included devcontainer. It pins the ROS base image and 
 4. Start the simulator and Foxglove bridge:
 
    ```bash
-   make sim
+   make experiment
    ```
+
+`make experiment` runs the safe example stance command and the interface monitor. Use `make sim` when you want the simulator/controller stack without an autonomous example command; the simulator still publishes the teaching sensor topics.
 
 The devcontainer runs `make build` after creation. Stop a running launch with `Ctrl-C`.
 
@@ -51,7 +53,7 @@ make setup
 make build
 make test
 make smoke
-make sim
+make experiment
 ```
 
 `make setup` installs dependencies declared by the ROS packages and creates `.venv` with the pinned packages from `requirements.txt`. It does not install ROS itself.
@@ -60,7 +62,7 @@ make sim
 
 PyBullet runs headlessly. The normal remote-workstation workflow is to render in Foxglove on your local machine:
 
-1. Run `make sim` on the workstation.
+1. Run `make experiment` on the workstation.
 2. Forward TCP port `8765`. VS Code forwards it automatically from the devcontainer, or use SSH:
 
    ```bash
@@ -82,10 +84,50 @@ make sim SIM_ARGS="use_rviz:=true use_foxglove:=false"
 | `make setup` | Resolve ROS dependencies and install pinned Python dependencies |
 | `make build` | Build `robot_ws` using a symlink install |
 | `make test` | Run all package tests and print the complete result summary |
-| `make smoke` | Launch the stack headlessly and verify `/joint_states` and `/tf` |
+| `make smoke` | Verify commands, sensor topics, contact forces, and ground truth together |
 | `make sim` | Launch PyBullet, the joint controller, robot state publisher, and Foxglove |
+| `make experiment` | Add the deterministic example controller and interface monitor |
 
 All commands accept a different installed ROS distribution through `ROS_DISTRO`, for example `ROS_DISTRO=humble make build`. Jazzy remains the tested target.
+
+## PyBullet teaching experiment
+
+The experiment launch is deliberately small. It is an interface for learning how control and state-estimation data move through a robot stack; it is **not** a state estimator and does not claim hardware fidelity.
+
+```mermaid
+flowchart LR
+    example["Example stance controller"] -->|/control_inputs| adapter["Closed-chain command adapter"]
+    adapter -->|/cmd_jnts| sim["Fixed-step PyBullet simulator"]
+    sim --> sensors["/sim/sensors/* (mock/idealized)"]
+    sim --> truth["/sim/ground_truth/odom"]
+    sensors --> monitor["Example interface monitor"]
+    truth --> monitor
+    monitor -->|all command and sensor streams observed| ready["/sim/experiment/ready"]
+```
+
+The example controller repeats a gentle, symmetric 4 mm stance-height cycle. It generates the same sample sequence every cycle and stays within the current adapter's configured joint limits. PyBullet advances with a fixed 10 ms physics step; ROS timers are not a hard real-time or lockstep scheduler.
+
+### Topic semantics
+
+| Topic | Type | Meaning |
+| --- | --- | --- |
+| `/control_inputs` | `sensor_msgs/msg/JointState` | Physical closed-chain angles in radians. Numeric names `0..11` use leg order front-right, rear-right, rear-left, front-left, with three angles per leg. |
+| `/cmd_jnts` | `sensor_msgs/msg/JointState` | Adapter output addressed by explicit simplified-URDF joint names. |
+| `/sim/sensors/imu` | `sensor_msgs/msg/Imu` | Ideal orientation, body-frame angular velocity, and body-frame specific force at `base_link`; no noise, bias, saturation, or covariance model. |
+| `/sim/sensors/joint_states` | `sensor_msgs/msg/JointState` | Ideal PyBullet joint position, velocity, and applied motor torque. `/joint_states` mirrors it for ROS visualization compatibility. |
+| `/sim/sensors/foot_contacts/<foot>` | `std_msgs/msg/Bool` | Binary plane contact for `front_left`, `front_right`, `rear_left`, or `rear_right`. |
+| `/sim/sensors/foot_contacts/<foot>/normal_force` | `std_msgs/msg/Float64` | Sum of PyBullet normal contact forces for that foot, in newtons. |
+| `/sim/sensors/foot_contacts/<foot>/wrench` | `geometry_msgs/msg/WrenchStamped` | Ideal PyBullet normal-plus-friction force in the corresponding foot-link frame, with torque about that link's origin. |
+| `/sim/ground_truth/odom` | `nav_msgs/msg/Odometry` | Exact simulated `world -> base_link` pose and body-frame twist. Keep this out of estimator inputs; use it for evaluation. |
+| `/sim/experiment/ready` | `std_msgs/msg/Bool` | The monitor has received every stream, command names match measured joint names, and at least one foot reports nonzero normal force. |
+
+Contact and force values come directly from the simplified PyBullet collision model. They are mock simulation data, not a model of a load cell, force-sensitive resistor, or any real hardware sensor.
+
+### First learning exercise: contact-aided vertical velocity
+
+Create a new node that subscribes to the IMU, joint states, and four foot-contact/normal-force topics. Rotate IMU specific force into `world`, add gravity, and integrate vertical acceleration. When at least two feet have stable contact above a small force threshold, apply a zero-vertical-velocity update. Plot the estimate against `/sim/ground_truth/odom`, but never subscribe to ground truth inside the estimator itself. Then add configurable IMU bias/noise in your exercise node and observe how the contact update changes drift.
+
+This exercise teaches frame transforms, IMU conventions, contact gating, and evaluation separation. It is only a starting point for a contact-aided estimator; it does not account for slip, contact uncertainty, kinematic velocity constraints, or filter consistency.
 
 ## Repository layout
 
@@ -114,7 +156,7 @@ An older, more detailed open-chain export of the mechanism exists in Git history
 1. **Reproducible baseline** — repeatable environment, declared dependencies, CI, and a verified PyBullet launch. This repository state covers that phase.
 2. **MuJoCo vertical slice** — load one canonical model, step deterministically, apply joint commands, publish state, and render offscreen.
 3. **Model fidelity** — recover the detailed mechanism, add loop-closure constraints, simplify collision geometry, and validate mass/inertia/joint conventions.
-4. **Robotics interfaces** — sensors, state-estimation exercises, navigation interfaces, and controller benchmarks.
+4. **Robotics interfaces** — the idealized sensor teaching slice has started this phase; state estimators, navigation interfaces, and controller benchmarks remain.
 5. **Learning environment** — Gymnasium-style reset/step API, observations/actions/rewards, reproducible experiments, and ROS adapters at the boundary.
 
 ## Project history

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+# Python runtime dependencies. ROS dependencies are installed through rosdep.
+numpy==1.26.4
+pybullet==3.2.7
+scipy==1.15.3

--- a/robot_ws/src/robot_controller/launch/quad_controller.launch.py
+++ b/robot_ws/src/robot_controller/launch/quad_controller.launch.py
@@ -1,17 +1,34 @@
 #!/usr/bin/env python3
 
 from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
+from launch_ros.parameter_descriptions import ParameterValue
 
 
 def generate_launch_description():
+    publish_initial_configuration = LaunchConfiguration(
+        'publish_initial_configuration'
+    )
     controller_launch = Node(
         package='robot_controller',
         executable='quad_controller',
         name='quad_controller',
         output='screen',
+        parameters=[{
+            'publish_initial_configuration': ParameterValue(
+                publish_initial_configuration,
+                value_type=bool,
+            ),
+        }],
     )
 
     return LaunchDescription([
+        DeclareLaunchArgument(
+            'publish_initial_configuration',
+            default_value='true',
+            description='Publish the built-in nominal stance once after startup.',
+        ),
         controller_launch,
     ])

--- a/robot_ws/src/robot_controller/launch/quad_controller.launch.py
+++ b/robot_ws/src/robot_controller/launch/quad_controller.launch.py
@@ -8,6 +8,7 @@ from launch_ros.parameter_descriptions import ParameterValue
 
 
 def generate_launch_description():
+    use_sim_time = LaunchConfiguration('use_sim_time')
     publish_initial_configuration = LaunchConfiguration(
         'publish_initial_configuration'
     )
@@ -17,6 +18,7 @@ def generate_launch_description():
         name='quad_controller',
         output='screen',
         parameters=[{
+            'use_sim_time': ParameterValue(use_sim_time, value_type=bool),
             'publish_initial_configuration': ParameterValue(
                 publish_initial_configuration,
                 value_type=bool,
@@ -25,6 +27,11 @@ def generate_launch_description():
     )
 
     return LaunchDescription([
+        DeclareLaunchArgument(
+            'use_sim_time',
+            default_value='true',
+            description='Use the fixed-step clock published by the simulator.',
+        ),
         DeclareLaunchArgument(
             'publish_initial_configuration',
             default_value='true',

--- a/robot_ws/src/robot_controller/launch/quad_controller.launch.py
+++ b/robot_ws/src/robot_controller/launch/quad_controller.launch.py
@@ -1,20 +1,17 @@
 #!/usr/bin/env python3
 
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument
-from launch.substitutions import Command, FindExecutable, LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import Node
-from launch_ros.substitutions import FindPackageShare
+
 
 def generate_launch_description():
-    
     controller_launch = Node(
         package='robot_controller',
         executable='quad_controller',
         name='quad_controller',
-        output='screen'
+        output='screen',
     )
-    
+
     return LaunchDescription([
-        controller_launch
+        controller_launch,
     ])

--- a/robot_ws/src/robot_controller/package.xml
+++ b/robot_ws/src/robot_controller/package.xml
@@ -2,10 +2,19 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>robot_controller</name>
-  <version>0.0.0</version>
-  <description>TODO: Package description</description>
-  <maintainer email="mahussein04@gmail.com">mahus</maintainer>
-  <license>TODO: License declaration</license>
+  <version>0.1.0</version>
+  <description>ROS 2 joint command adapter and leg kinematics for the robot dog.</description>
+  <maintainer email="mahussein04@gmail.com">Mostafa Hussein</maintainer>
+  <license>NOASSERTION</license>
+
+  <buildtool_depend>ament_python</buildtool_depend>
+
+  <depend>rclpy</depend>
+  <depend>sensor_msgs</depend>
+
+  <exec_depend>launch</exec_depend>
+  <exec_depend>launch_ros</exec_depend>
+  <exec_depend>python3-numpy</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/robot_ws/src/robot_controller/package.xml
+++ b/robot_ws/src/robot_controller/package.xml
@@ -7,8 +7,6 @@
   <maintainer email="mahussein04@gmail.com">Mostafa Hussein</maintainer>
   <license>NOASSERTION</license>
 
-  <buildtool_depend>ament_python</buildtool_depend>
-
   <depend>rclpy</depend>
   <depend>sensor_msgs</depend>
 

--- a/robot_ws/src/robot_controller/robot_controller/example_stance_controller.py
+++ b/robot_ws/src/robot_controller/robot_controller/example_stance_controller.py
@@ -1,0 +1,82 @@
+"""Publish a deterministic, gentle stance command for teaching experiments."""
+
+from math import pi, sin
+
+import numpy as np
+import rclpy
+from rclpy.node import Node
+from robot_controller.leg_kin import LegKin
+from sensor_msgs.msg import JointState
+
+
+LEG_RIGHT = (True, True, False, False)
+SHOULDER_OFFSET_METERS = 0.038
+NOMINAL_FOOT_HEIGHT_METERS = 0.14
+HEIGHT_AMPLITUDE_METERS = 0.004
+
+
+class StancePattern:
+    """Generate a fixed-step, symmetric stance-height exercise."""
+
+    def __init__(self, steps_per_cycle=80):
+        if steps_per_cycle < 1:
+            raise ValueError('steps_per_cycle must be positive')
+        self.steps_per_cycle = steps_per_cycle
+        self.kinematics = LegKin()
+
+    def command(self, step):
+        """Return 12 physical-leg angles for a deterministic cycle step."""
+        phase = 2 * pi * (step % self.steps_per_cycle) / self.steps_per_cycle
+        foot_z = -NOMINAL_FOOT_HEIGHT_METERS + HEIGHT_AMPLITUDE_METERS * sin(phase)
+        angles = []
+        for right in LEG_RIGHT:
+            foot_y = -SHOULDER_OFFSET_METERS if right else SHOULDER_OFFSET_METERS
+            leg_angles = self.kinematics.leg_ik(0.0, foot_y, foot_z, right=right)
+            if not np.all(np.isfinite(leg_angles)):
+                raise RuntimeError('stance pattern produced an invalid IK result')
+            angles.extend(float(value) for value in leg_angles)
+        return angles
+
+
+class ExampleStanceController(Node):
+    """Publish the stance pattern through the existing controller adapter."""
+
+    def __init__(self):
+        super().__init__('example_stance_controller')
+        self.declare_parameter('publish_rate_hz', 20.0)
+        self.declare_parameter('cycle_period_seconds', 4.0)
+
+        publish_rate = float(self.get_parameter('publish_rate_hz').value)
+        cycle_period = float(self.get_parameter('cycle_period_seconds').value)
+        if publish_rate <= 0.0 or cycle_period <= 0.0:
+            raise ValueError('publish rate and cycle period must be positive')
+
+        steps_per_cycle = max(1, round(publish_rate * cycle_period))
+        self.pattern = StancePattern(steps_per_cycle)
+        self.step = 0
+        self.publisher = self.create_publisher(JointState, '/control_inputs', 10)
+        self.timer = self.create_timer(1.0 / publish_rate, self.publish_command)
+
+    def publish_command(self):
+        """Publish one sample of the repeatable stance-height command."""
+        message = JointState()
+        message.header.stamp = self.get_clock().now().to_msg()
+        message.name = [str(index) for index in range(12)]
+        message.position = self.pattern.command(self.step)
+        self.publisher.publish(message)
+        self.step += 1
+
+
+def main(args=None):
+    """Start the deterministic example stance controller."""
+    rclpy.init(args=args)
+    controller = ExampleStanceController()
+    try:
+        rclpy.spin(controller)
+    finally:
+        controller.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/robot_ws/src/robot_controller/robot_controller/gaits.py
+++ b/robot_ws/src/robot_controller/robot_controller/gaits.py
@@ -1,51 +1,55 @@
-import numpy as np
+"""Placeholder interfaces for future gait implementations."""
+
 from abc import ABC, abstractmethod
 import time
 
-# assume this is run at 1000 hz (every ms)
-__time_step__ = 0.001
+
+TIME_STEP_SECONDS = 0.001
+
 
 class Gait(ABC):
-  def __init__(self):
-    self.time_start = time.time()
-    self.started = False
+    """Base interface for time-stepped gait generators."""
 
-  @abstractmethod
-  def step(self, heading: float, speed: float):
-    pass
+    def __init__(self):
+        self.time_start = time.time()
+        self.started = False
 
-  def reset(self):
-    self.started = False
+    @abstractmethod
+    def step(self, heading, speed):
+        """Advance the gait and return its next command."""
+
+    def reset(self):
+        """Reset gait execution state."""
+        self.started = False
 
 
 class Walk(Gait):
-  def __init__(self):
-    pass
+    """Reserved interface for a walk gait."""
 
-  def step(self, heading: float, speed: float):
-    pass
+    def step(self, heading, speed):
+        """Advance the unimplemented walk gait."""
+        raise NotImplementedError
 
 
 class Crawl(Gait):
-  def __init__(self):
-    pass
+    """Reserved interface for a crawl gait."""
 
-  def step(self, heading: float, speed: float):
-    pass
+    def step(self, heading, speed):
+        """Advance the unimplemented crawl gait."""
+        raise NotImplementedError
 
 
 class Trot(Gait):
-  def __init__(self):
-    pass
+    """Reserved interface for a trot gait."""
 
-  def step(self, heading: float, speed: float):
-    pass
+    def step(self, heading, speed):
+        """Advance the unimplemented trot gait."""
+        raise NotImplementedError
+
 
 class Gallop(Gait):
-  def __init__(self):
-    pass
+    """Reserved interface for a gallop gait."""
 
-  def step(self, heading: float, speed: float):
-    pass
-
-
+    def step(self, heading, speed):
+        """Advance the unimplemented gallop gait."""
+        raise NotImplementedError

--- a/robot_ws/src/robot_controller/robot_controller/leg_kin.py
+++ b/robot_ws/src/robot_controller/robot_controller/leg_kin.py
@@ -1,90 +1,98 @@
+"""Kinematics helpers for the physical closed-chain leg geometry."""
+
 import numpy as np
 
 
 class LegKin:
-  # TODO: did this at midnight, something is wrong just cant find it
-  # using it for now :/
-  def __init__(self) -> None:
-    self.shoulder_len = 0.038
-    self.a_len = 0.1059
-    self.b_len = 0.0245
-    self.c_len = 0.047434
-    self.d_len = 0.063725
-    self.e_len = 0.11058
-    pass
+    """Solve leg IK and map physical angles onto the simplified URDF joints."""
 
-  def leg_ik(self, relative_x: float, relative_y: float, relative_z: float, right: bool) -> tuple:
-    theta_0, target_z = self._yz_plane_ik(relative_y, relative_z, right)
-    theta_1, theta_2 = self._xz_plane_ik(relative_x, target_z)
+    def __init__(self):
+        self.shoulder_len = 0.038
+        self.a_len = 0.1059
+        self.b_len = 0.0245
+        self.c_len = 0.047434
+        self.d_len = 0.063725
+        self.e_len = 0.11058
 
-    return (theta_0, theta_1, theta_2)
-  
-  def leg_control_conv(self, theta_0: float, theta_1:float, theta_2: float) -> list:
-    theta_1_prime = theta_1 - np.pi/2
-    upper_inner = np.pi - theta_1 + theta_2
-    alpha = (self.a_len ** 2 + self.b_len ** 2 - 2 * self.a_len * self.b_len * np.cos(upper_inner)) ** (1/2)
-    beta_upper = np.arccos((self.b_len ** 2 - self.a_len ** 2 - alpha ** 2) / (-2 * self.a_len * alpha)) 
-    beta_lower = np.arccos((self.e_len ** 2 - self.c_len ** 2 - alpha ** 2) / (-2 * self.c_len * alpha))
-    beta = beta_upper + beta_lower
-    theta_2_prime = np.pi - beta
+    def leg_ik(self, relative_x, relative_y, relative_z, right):
+        """Return three physical joint angles for a Cartesian foot target."""
+        theta_0, target_z = self._yz_plane_ik(relative_y, relative_z, right)
+        theta_1, theta_2 = self._xz_plane_ik(relative_x, target_z)
+        return theta_0, theta_1, theta_2
 
-    return (theta_0, theta_1_prime, theta_2_prime)
+    def leg_control_conversion(self, theta_0, theta_1, theta_2):
+        """Map physical closed-chain angles to the simplified URDF joints."""
+        theta_1_prime = theta_1 - np.pi / 2
+        upper_inner = np.pi - theta_1 + theta_2
+        alpha = np.sqrt(
+            self.a_len ** 2
+            + self.b_len ** 2
+            - 2 * self.a_len * self.b_len * np.cos(upper_inner)
+        )
+        beta_upper = np.arccos(
+            (self.b_len ** 2 - self.a_len ** 2 - alpha ** 2)
+            / (-2 * self.a_len * alpha)
+        )
+        beta_lower = np.arccos(
+            (self.e_len ** 2 - self.c_len ** 2 - alpha ** 2)
+            / (-2 * self.c_len * alpha)
+        )
+        theta_2_prime = np.pi - (beta_upper + beta_lower)
+        return theta_0, theta_1_prime, theta_2_prime
 
-  def _yz_plane_ik (self, relative_y: float, relative_z: float, right: bool) -> tuple:
-    relative_dist_sqr = relative_y ** 2 + relative_z ** 2
+    def leg_control_conv(self, theta_0, theta_1, theta_2):
+        """Preserve the original short name for downstream callers."""
+        return self.leg_control_conversion(theta_0, theta_1, theta_2)
 
-    target_len = (relative_dist_sqr - self.shoulder_len ** 2) ** (1/2)
-    if (relative_z < 0):
-      target_len *= -1
+    def _yz_plane_ik(self, relative_y, relative_z, right):
+        relative_dist_sqr = relative_y ** 2 + relative_z ** 2
+        target_len = np.sqrt(relative_dist_sqr - self.shoulder_len ** 2)
+        if relative_z < 0:
+            target_len *= -1
 
-    phi_0 = np.arccos(self.shoulder_len / (relative_dist_sqr ** (1/2)))
-    
-    if right:
-      phi = np.arctan2(relative_z, relative_y)
-    else:
-      phi = np.arctan2(relative_z, -relative_y)
+        phi_0 = np.arccos(self.shoulder_len / np.sqrt(relative_dist_sqr))
+        phi = np.arctan2(relative_z, relative_y if right else -relative_y)
+        if phi < 0:
+            phi += 2 * np.pi
 
-    if phi < 0:
-      phi += 2 * np.pi
+        theta = phi_0 - (phi - np.pi)
+        return theta, target_len
 
-    phi_prime = phi - np.pi
-    theta = phi_0 - phi_prime
+    def _xz_plane_ik(self, relative_x, relative_z):
+        relative_dist_sqr = relative_x ** 2 + relative_z ** 2
+        relative_dist = np.sqrt(relative_dist_sqr)
+        combined_lower_len = self.c_len + self.d_len
 
-    return (theta, target_len)
-  
-  def _xz_plane_ik(self, relative_x: float, relative_z: float) -> tuple:
-    relative_dist_sqr = relative_x ** 2 + relative_z ** 2
+        phi_prime = np.arccos(
+            (combined_lower_len ** 2 - self.a_len ** 2 - relative_dist_sqr)
+            / (-2 * self.a_len * relative_dist)
+        )
+        beta = np.arccos(
+            (relative_dist_sqr - self.a_len ** 2 - combined_lower_len ** 2)
+            / (-2 * self.a_len * combined_lower_len)
+        )
+        phi = np.arctan2(relative_z, relative_x)
+        if phi < 0:
+            phi += 2 * np.pi
 
-    f = self.c_len + self.d_len
+        theta_1 = phi - np.pi - phi_prime
+        internal_len_sqr = (
+            self.a_len ** 2
+            + self.c_len ** 2
+            - 2 * self.a_len * self.c_len * np.cos(beta)
+        )
+        internal_len = np.sqrt(internal_len_sqr)
+        phi_1_prime = np.arccos(
+            (self.e_len ** 2 - internal_len_sqr - self.b_len ** 2)
+            / (-2 * internal_len * self.b_len)
+        )
+        correction = np.arccos(
+            (self.d_len ** 2 - relative_dist_sqr - internal_len_sqr)
+            / (-2 * relative_dist * internal_len)
+        )
+        theta_2 = (2 * np.pi - phi) - phi_1_prime + correction
+        return theta_1, -theta_2
 
-    phi_prime_num = f ** 2 - self.a_len ** 2 - relative_dist_sqr
-    phi_prime_den = -2 * self.a_len * relative_dist_sqr**(1/2)
-    phi_prime = np.arccos(phi_prime_num/ phi_prime_den)
-    
-    beta_numerator = relative_dist_sqr - self.a_len ** 2 - f ** 2
-    beta_denominator = - 2 * self.a_len * f
-    beta = np.arccos(beta_numerator / beta_denominator)
-    
-    phi = np.arctan2(relative_z, relative_x)
-
-    if phi < 0:
-      phi += 2 * np.pi
-
-    theta_1 = phi - np.pi - phi_prime
-    
-    internal_len_sqr = self.a_len ** 2 + self.c_len ** 2 - 2 * self.a_len * self.c_len * np.cos(beta)
-    phi_1_prime_num = self.e_len ** 2 - internal_len_sqr - self.b_len ** 2
-    phi_1_prime_den = - 2 * internal_len_sqr ** (1/2) * self.b_len
-    phi_1_prime = np.arccos(phi_1_prime_num / phi_1_prime_den)
-    phi_1 = 2 * np.pi - phi
-
-    correction_num = self.d_len ** 2 - relative_dist_sqr - internal_len_sqr
-    correction_den = - 2 * relative_dist_sqr ** (1/2) * internal_len_sqr ** (1/2)
-    correction = np.arccos(correction_num/correction_den)
-
-    theta_2 = phi_1 - phi_1_prime + correction
-
-    return (theta_1, -theta_2)
-
-  def _len(self, point: tuple):
-    return (point[0]**2, point[1]**2)**(1/2) 
+    @staticmethod
+    def _length(point):
+        return np.hypot(point[0], point[1])

--- a/robot_ws/src/robot_controller/robot_controller/quad_joint_controller.py
+++ b/robot_ws/src/robot_controller/robot_controller/quad_joint_controller.py
@@ -1,95 +1,104 @@
-import rclpy 
-from rclpy.node import Node
-from sensor_msgs.msg import JointState
-from robot_controller.leg_kin import LegKin
+"""Translate Cartesian leg targets into simulated joint commands."""
+
 import numpy as np
-import time
+import rclpy
+from rclpy.node import Node
+from robot_controller.leg_kin import LegKin
+from sensor_msgs.msg import JointState
 
-class Joint_Controller(Node):
-  def __init__(self):
-    super().__init__('quadruped_joint_controller')
 
-    # Create publisher
-    self.pub = self.create_publisher(JointState, "/cmd_jnts", 10)\
-    
-    self.cmd_sub = self.create_subscription(
-       JointState,
-       "/control_inputs",
-       self.cmd_callback,
-       10
-    )
+class JointController(Node):
+    """Adapt physical leg commands to the simplified simulation joints."""
 
-    time.sleep(10)
-    
-    self.leg_kin = LegKin()
+    def __init__(self):
+        super().__init__('quadruped_joint_controller')
 
-    # Initial configuration for each leg:
-    init_x, init_y, init_z = (0.0, 0.038, 0.14)
-    init_config = [[init_x, -init_y, -init_z],[init_x, -init_y, -init_z],[init_x, init_y, -init_z],[init_x, init_y, -init_z]]
-    self.cmd_config(init_config)
+        self.leg_kinematics = LegKin()
+        self.command_publisher = self.create_publisher(JointState, '/cmd_jnts', 10)
+        self.control_subscription = self.create_subscription(
+            JointState,
+            '/control_inputs',
+            self.command_callback,
+            10,
+        )
+        self.initialization_timer = self.create_timer(1.0, self._publish_initial_configuration)
 
-  def cmd_config(self, config: list):
-    bad = False
-    msg = JointState()
-    for i in range(len(config)):
-      right = True
-      if i > 1:
-        right = False
-      
-      try:
-        t0, t1, t2 = self.leg_kin.leg_ik(config[i][0],config[i][1],config[i][2], right)
-        t0,t1,t2 = self.leg_kin.leg_control_conv(t0, t1, t2)
-        joints = [t0,t1,t2]
-      except:
-        bad = True
+    def _publish_initial_configuration(self):
+        self.initialization_timer.cancel()
+        initial_x, initial_y, initial_z = (0.0, 0.038, 0.14)
+        initial_configuration = [
+            [initial_x, -initial_y, -initial_z],
+            [initial_x, -initial_y, -initial_z],
+            [initial_x, initial_y, -initial_z],
+            [initial_x, initial_y, -initial_z],
+        ]
+        self.command_configuration(initial_configuration)
 
-      for j in range(3):
-        if np.isnan(joints[j]):
-          bad = True
-        msg.name.append(str(i*3 + j))
-        msg.position.append(joints[j])
+    def command_configuration(self, configuration):
+        """Publish a four-leg Cartesian target when all IK results are valid."""
+        message = JointState()
+        for leg_index, leg_target in enumerate(configuration):
+            right_leg = leg_index <= 1
+            angles = self.leg_kinematics.leg_ik(*leg_target, right=right_leg)
+            joints = self.leg_kinematics.leg_control_conversion(*angles)
+            if not np.all(np.isfinite(joints)):
+                self.get_logger().warning('Ignoring unreachable leg target %s', leg_target)
+                return
 
-    if not bad:
-      self.pub.publish(msg)
+            for joint_offset, joint_position in enumerate(joints):
+                message.name.append(str(leg_index * 3 + joint_offset))
+                message.position.append(joint_position)
 
-  def cmd_callback(self, msg: JointState):
-    angles = [0,0,0,0,0,0,0,0,0,0,0,0]
-    for i in range(len(msg.name)):
-      jointNum = int(msg.name[i])
-      angles[jointNum] = msg.position[jointNum]
+        self.command_publisher.publish(message)
 
-    msg = JointState()
-    for leg in range(4):
-      t0, t1, t2 = angles[leg * 3: leg*3 + 3]
+    def cmd_config(self, configuration):
+        """Preserve the original command method name for downstream callers."""
+        self.command_configuration(configuration)
 
-      if abs(t0) > np.pi/2 or t1 > np.pi/2 or t1 < -np.pi/6 or t2 > 7 * np.pi / 18 or t2 < -7 * np.pi / 18:
-        return
+    def command_callback(self, input_message):
+        """Validate and convert indexed physical joint commands."""
+        angles = [0.0] * 12
+        for name, position in zip(input_message.name, input_message.position):
+            joint_index = int(name)
+            if not 0 <= joint_index < len(angles):
+                self.get_logger().warning('Ignoring out-of-range joint index %s', name)
+                return
+            angles[joint_index] = position
 
-      try:
-        t0,t1,t2 = self.leg_kin.leg_control_conv(t0, t1, t2)
-      except:
-        return
-      
-      joints = [t0,t1,t2]
+        output_message = JointState()
+        for leg_index in range(4):
+            theta_0, theta_1, theta_2 = angles[leg_index * 3:leg_index * 3 + 3]
+            outside_limits = (
+                abs(theta_0) > np.pi / 2
+                or not -np.pi / 6 <= theta_1 <= np.pi / 2
+                or not -7 * np.pi / 18 <= theta_2 <= 7 * np.pi / 18
+            )
+            if outside_limits:
+                self.get_logger().warning('Ignoring command outside configured joint limits')
+                return
 
-      for i in range(3):
-        msg.name.append(str(leg*3 + i))
-        msg.position.append(joints[i])
+            joints = self.leg_kinematics.leg_control_conversion(theta_0, theta_1, theta_2)
+            if not np.all(np.isfinite(joints)):
+                self.get_logger().warning('Ignoring command with invalid kinematic result')
+                return
 
-    self.pub.publish(msg)
+            for joint_offset, joint_position in enumerate(joints):
+                output_message.name.append(str(leg_index * 3 + joint_offset))
+                output_message.position.append(joint_position)
 
-def main(args = None):
-  rclpy.init(args=args)
+        self.command_publisher.publish(output_message)
 
-  joint_control = Joint_Controller()
 
-  rclpy.spin(joint_control)
-
-  joint_control.destroy_node()
-  rclpy.shutdown()
+def main(args=None):
+    """Start the ROS 2 joint controller node."""
+    rclpy.init(args=args)
+    controller = JointController()
+    try:
+        rclpy.spin(controller)
+    finally:
+        controller.destroy_node()
+        rclpy.shutdown()
 
 
 if __name__ == '__main__':
-  main()
-
-  
+    main()

--- a/robot_ws/src/robot_controller/robot_controller/quad_joint_controller.py
+++ b/robot_ws/src/robot_controller/robot_controller/quad_joint_controller.py
@@ -7,6 +7,14 @@ from robot_controller.leg_kin import LegKin
 from sensor_msgs.msg import JointState
 
 
+SIM_JOINT_NAMES_BY_LEG = (
+    ('Revolute_1', 'Revolute_25', 'Revolute_40'),
+    ('Revolute_3', 'Revolute_20', 'Revolute_23'),
+    ('Revolute_4', 'Revolute_35', 'Revolute_45'),
+    ('Revolute_5', 'Revolute_31', 'Revolute_48'),
+)
+
+
 class JointController(Node):
     """Adapt physical leg commands to the simplified simulation joints."""
 
@@ -21,10 +29,17 @@ class JointController(Node):
             self.command_callback,
             10,
         )
-        self.initialization_timer = self.create_timer(1.0, self._publish_initial_configuration)
+        self.declare_parameter('publish_initial_configuration', True)
+        self.initialization_timer = None
+        if self.get_parameter('publish_initial_configuration').value:
+            self.initialization_timer = self.create_timer(
+                1.0,
+                self._publish_initial_configuration,
+            )
 
     def _publish_initial_configuration(self):
-        self.initialization_timer.cancel()
+        if self.initialization_timer is not None:
+            self.initialization_timer.cancel()
         initial_x, initial_y, initial_z = (0.0, 0.038, 0.14)
         initial_configuration = [
             [initial_x, -initial_y, -initial_z],
@@ -37,16 +52,22 @@ class JointController(Node):
     def command_configuration(self, configuration):
         """Publish a four-leg Cartesian target when all IK results are valid."""
         message = JointState()
+        message.header.stamp = self.get_clock().now().to_msg()
         for leg_index, leg_target in enumerate(configuration):
             right_leg = leg_index <= 1
             angles = self.leg_kinematics.leg_ik(*leg_target, right=right_leg)
             joints = self.leg_kinematics.leg_control_conversion(*angles)
             if not np.all(np.isfinite(joints)):
-                self.get_logger().warning('Ignoring unreachable leg target %s', leg_target)
+                self.get_logger().warning(
+                    f'Ignoring unreachable leg target {leg_target}'
+                )
                 return
 
-            for joint_offset, joint_position in enumerate(joints):
-                message.name.append(str(leg_index * 3 + joint_offset))
+            for joint_name, joint_position in zip(
+                SIM_JOINT_NAMES_BY_LEG[leg_index],
+                joints,
+            ):
+                message.name.append(joint_name)
                 message.position.append(joint_position)
 
         self.command_publisher.publish(message)
@@ -57,15 +78,35 @@ class JointController(Node):
 
     def command_callback(self, input_message):
         """Validate and convert indexed physical joint commands."""
-        angles = [0.0] * 12
+        if len(input_message.name) != len(input_message.position):
+            self.get_logger().warning('Ignoring command with mismatched names and positions')
+            return
+
+        angles = [None] * 12
         for name, position in zip(input_message.name, input_message.position):
-            joint_index = int(name)
+            try:
+                joint_index = int(name)
+            except ValueError:
+                self.get_logger().warning(
+                    f'Ignoring non-numeric physical joint name {name}'
+                )
+                return
             if not 0 <= joint_index < len(angles):
-                self.get_logger().warning('Ignoring out-of-range joint index %s', name)
+                self.get_logger().warning(f'Ignoring out-of-range joint index {name}')
+                return
+            if angles[joint_index] is not None:
+                self.get_logger().warning(
+                    f'Ignoring command with duplicate joint index {name}'
+                )
                 return
             angles[joint_index] = position
 
+        if any(angle is None for angle in angles):
+            self.get_logger().warning('Ignoring incomplete physical joint command')
+            return
+
         output_message = JointState()
+        output_message.header.stamp = self.get_clock().now().to_msg()
         for leg_index in range(4):
             theta_0, theta_1, theta_2 = angles[leg_index * 3:leg_index * 3 + 3]
             outside_limits = (
@@ -82,8 +123,11 @@ class JointController(Node):
                 self.get_logger().warning('Ignoring command with invalid kinematic result')
                 return
 
-            for joint_offset, joint_position in enumerate(joints):
-                output_message.name.append(str(leg_index * 3 + joint_offset))
+            for joint_name, joint_position in zip(
+                SIM_JOINT_NAMES_BY_LEG[leg_index],
+                joints,
+            ):
+                output_message.name.append(joint_name)
                 output_message.position.append(joint_position)
 
         self.command_publisher.publish(output_message)

--- a/robot_ws/src/robot_controller/setup.py
+++ b/robot_ws/src/robot_controller/setup.py
@@ -1,24 +1,25 @@
-from setuptools import find_packages, setup
 from glob import glob
+
+from setuptools import find_packages, setup
 
 package_name = 'robot_controller'
 
 setup(
     name=package_name,
-    version='0.0.0',
+    version='0.1.0',
     packages=find_packages(exclude=['test']),
     data_files=[
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),
         ('share/' + package_name, ['package.xml']),
-        ('share/' + package_name + "/launch", glob('launch/*.launch.py')),
+        ('share/' + package_name + '/launch', glob('launch/*.launch.py')),
     ],
-    install_requires=['setuptools'],
+    install_requires=['numpy', 'setuptools'],
     zip_safe=True,
-    maintainer='mahus',
+    maintainer='Mostafa Hussein',
     maintainer_email='mahussein04@gmail.com',
-    description='TODO: Package description',
-    license='TODO: License declaration',
+    description='ROS 2 joint command adapter and leg kinematics for the robot dog.',
+    license='NOASSERTION',
     tests_require=['pytest'],
     entry_points={
         'console_scripts': [

--- a/robot_ws/src/robot_controller/setup.py
+++ b/robot_ws/src/robot_controller/setup.py
@@ -23,6 +23,8 @@ setup(
     tests_require=['pytest'],
     entry_points={
         'console_scripts': [
+            'example_stance_controller = '
+            'robot_controller.example_stance_controller:main',
             'quad_controller = robot_controller.quad_joint_controller:main',
         ],
     },

--- a/robot_ws/src/robot_controller/test/test_example_stance_controller.py
+++ b/robot_ws/src/robot_controller/test/test_example_stance_controller.py
@@ -1,0 +1,26 @@
+"""Tests for the deterministic example stance controller."""
+
+import numpy as np
+
+from robot_controller.example_stance_controller import StancePattern
+
+
+def test_stance_pattern_is_periodic_finite_and_within_adapter_limits():
+    pattern = StancePattern(steps_per_cycle=80)
+
+    first_command = pattern.command(0)
+    assert first_command == pattern.command(80)
+
+    for step in range(80):
+        command = np.asarray(pattern.command(step)).reshape(4, 3)
+        assert np.all(np.isfinite(command))
+        assert np.all(np.abs(command[:, 0]) <= np.pi / 2)
+        assert np.all(command[:, 1] >= -np.pi / 6)
+        assert np.all(command[:, 1] <= np.pi / 2)
+        assert np.all(command[:, 2] >= -7 * np.pi / 18)
+        assert np.all(command[:, 2] <= 7 * np.pi / 18)
+        converted = [
+            pattern.kinematics.leg_control_conversion(*leg_angles)
+            for leg_angles in command
+        ]
+        assert np.all(np.isfinite(converted))

--- a/robot_ws/src/robot_desc/launch/view_robot.launch.py
+++ b/robot_ws/src/robot_desc/launch/view_robot.launch.py
@@ -6,12 +6,14 @@ from launch.conditions import IfCondition
 from launch.launch_description_sources import AnyLaunchDescriptionSource
 from launch.substitutions import Command, FindExecutable, LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import Node
+from launch_ros.parameter_descriptions import ParameterValue
 from launch_ros.substitutions import FindPackageShare
 
 
 def generate_launch_description():
     use_foxglove = LaunchConfiguration('use_foxglove')
     use_rviz = LaunchConfiguration('use_rviz')
+    use_sim_time = LaunchConfiguration('use_sim_time')
 
     robot_description_content = Command(
         [
@@ -33,7 +35,10 @@ def generate_launch_description():
         executable='robot_state_publisher',
         name='robot_state_publisher',
         output='screen',
-        parameters=[robot_description],
+        parameters=[
+            robot_description,
+            {'use_sim_time': ParameterValue(use_sim_time, value_type=bool)},
+        ],
     )
 
     rviz_launch = Node(
@@ -45,6 +50,9 @@ def generate_launch_description():
             '-d',
             PathJoinSubstitution([FindPackageShare('robot_desc'), 'rviz', 'view_robot.rviz']),
         ],
+        parameters=[{
+            'use_sim_time': ParameterValue(use_sim_time, value_type=bool),
+        }],
         condition=IfCondition(use_rviz),
     )
 
@@ -58,6 +66,11 @@ def generate_launch_description():
     )
 
     return LaunchDescription([
+        DeclareLaunchArgument(
+            'use_sim_time',
+            default_value='true',
+            description='Use the fixed-step clock published by the simulator.',
+        ),
         DeclareLaunchArgument(
             'use_foxglove',
             default_value='true',

--- a/robot_ws/src/robot_desc/launch/view_robot.launch.py
+++ b/robot_ws/src/robot_desc/launch/view_robot.launch.py
@@ -1,36 +1,39 @@
 #!/usr/bin/env python3
 
 from launch import LaunchDescription
-from launch.actions import IncludeLaunchDescription
-from launch.substitutions import PathJoinSubstitution
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
+from launch.conditions import IfCondition
+from launch.launch_description_sources import AnyLaunchDescriptionSource
 from launch.substitutions import Command, FindExecutable, LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
-from launch_xml.launch_description_sources import XMLLaunchDescriptionSource
+
 
 def generate_launch_description():
+    use_foxglove = LaunchConfiguration('use_foxglove')
+    use_rviz = LaunchConfiguration('use_rviz')
 
     robot_description_content = Command(
         [
-            PathJoinSubstitution([FindExecutable(name="xacro")]),
-            " ",
+            PathJoinSubstitution([FindExecutable(name='xacro')]),
+            ' ',
             PathJoinSubstitution(
                 [
-                    FindPackageShare("robot_desc"),
-                    "urdf",
-                    "quad.xacro",
+                    FindPackageShare('robot_desc'),
+                    'urdf',
+                    'quad.xacro',
                 ]
             ),
         ]
     )
-    robot_description = {"robot_description": robot_description_content}
+    robot_description = {'robot_description': robot_description_content}
 
     robot_state_pub = Node(
         package='robot_state_publisher',
         executable='robot_state_publisher',
         name='robot_state_publisher',
         output='screen',
-        parameters=[robot_description]
+        parameters=[robot_description],
     )
 
     rviz_launch = Node(
@@ -38,18 +41,34 @@ def generate_launch_description():
         executable='rviz2',
         name='rviz2',
         output='screen',
-        arguments=['-d', PathJoinSubstitution([FindPackageShare("robot_desc"), "rviz", "view_robot.rviz"])]
+        arguments=[
+            '-d',
+            PathJoinSubstitution([FindPackageShare('robot_desc'), 'rviz', 'view_robot.rviz']),
+        ],
+        condition=IfCondition(use_rviz),
     )
-    
+
     foxglove_launch_file = PathJoinSubstitution(
         [FindPackageShare('foxglove_bridge'), 'launch', 'foxglove_bridge_launch.xml']
     )
 
     foxglove_launch = IncludeLaunchDescription(
-        XMLLaunchDescriptionSource(foxglove_launch_file)
+        AnyLaunchDescriptionSource(foxglove_launch_file),
+        condition=IfCondition(use_foxglove),
     )
 
     return LaunchDescription([
+        DeclareLaunchArgument(
+            'use_foxglove',
+            default_value='true',
+            description='Start the Foxglove WebSocket bridge on port 8765.',
+        ),
+        DeclareLaunchArgument(
+            'use_rviz',
+            default_value='false',
+            description='Start RViz (requires a graphical display).',
+        ),
         robot_state_pub,
-        foxglove_launch
+        rviz_launch,
+        foxglove_launch,
     ])

--- a/robot_ws/src/robot_desc/package.xml
+++ b/robot_ws/src/robot_desc/package.xml
@@ -2,10 +2,20 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>robot_desc</name>
-  <version>0.0.0</version>
-  <description>TODO: Package description</description>
-  <maintainer email="mahussein04@gmail.com">mahus</maintainer>
-  <license>TODO: License declaration</license>
+  <version>0.1.0</version>
+  <description>Simplified robot description and visualization launch files.</description>
+  <maintainer email="mahussein04@gmail.com">Mostafa Hussein</maintainer>
+  <license>NOASSERTION</license>
+
+  <buildtool_depend>ament_python</buildtool_depend>
+
+  <exec_depend>foxglove_bridge</exec_depend>
+  <exec_depend>launch</exec_depend>
+  <exec_depend>launch_ros</exec_depend>
+  <exec_depend>launch_xml</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>rviz2</exec_depend>
+  <exec_depend>xacro</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/robot_ws/src/robot_desc/package.xml
+++ b/robot_ws/src/robot_desc/package.xml
@@ -7,8 +7,6 @@
   <maintainer email="mahussein04@gmail.com">Mostafa Hussein</maintainer>
   <license>NOASSERTION</license>
 
-  <buildtool_depend>ament_python</buildtool_depend>
-
   <exec_depend>foxglove_bridge</exec_depend>
   <exec_depend>launch</exec_depend>
   <exec_depend>launch_ros</exec_depend>

--- a/robot_ws/src/robot_desc/setup.py
+++ b/robot_ws/src/robot_desc/setup.py
@@ -1,28 +1,29 @@
-from setuptools import find_packages, setup
 from glob import glob
+
+from setuptools import find_packages, setup
 
 package_name = 'robot_desc'
 
 setup(
     name=package_name,
-    version='0.0.0',
+    version='0.1.0',
     packages=find_packages(exclude=['test']),
     data_files=[
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),
         ('share/' + package_name, ['package.xml']),
-        ('share/' + package_name + "/launch", glob('launch/*.launch.py')),
-        ('share/' + package_name + "/rviz", glob('rviz/*.rviz')),
-        ('share/' + package_name + "/urdf", glob('urdf/*.xacro')),
-        ('share/' + package_name + "/urdf", glob('urdf/*.trans')),
-        ('share/' + package_name + "/urdf/meshes", glob('urdf/meshes/*.stl')),
+        ('share/' + package_name + '/launch', glob('launch/*.launch.py')),
+        ('share/' + package_name + '/rviz', glob('rviz/*.rviz')),
+        ('share/' + package_name + '/urdf', glob('urdf/*.xacro')),
+        ('share/' + package_name + '/urdf', glob('urdf/*.trans')),
+        ('share/' + package_name + '/urdf/meshes', glob('urdf/meshes/*.stl')),
     ],
     install_requires=['setuptools'],
     zip_safe=True,
-    maintainer='mahus',
+    maintainer='Mostafa Hussein',
     maintainer_email='mahussein04@gmail.com',
-    description='TODO: Package description',
-    license='TODO: License declaration',
+    description='Simplified robot description and visualization launch files.',
+    license='NOASSERTION',
     tests_require=['pytest'],
     entry_points={
         'console_scripts': [

--- a/robot_ws/src/robot_simulation/launch/experiment.launch.py
+++ b/robot_ws/src/robot_simulation/launch/experiment.launch.py
@@ -7,12 +7,15 @@ from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import Node
+from launch_ros.parameter_descriptions import ParameterValue
 from launch_ros.substitutions import FindPackageShare
 
 
 def generate_launch_description():
+    use_sim_time = LaunchConfiguration('use_sim_time')
     use_foxglove = LaunchConfiguration('use_foxglove')
     use_rviz = LaunchConfiguration('use_rviz')
+    publish_ground_truth_tf = LaunchConfiguration('publish_ground_truth_tf')
     master_launch_file = PathJoinSubstitution(
         [FindPackageShare('robot_simulation'), 'launch', 'master.launch.py']
     )
@@ -20,9 +23,11 @@ def generate_launch_description():
     stack = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(master_launch_file),
         launch_arguments={
+            'use_sim_time': use_sim_time,
             'use_foxglove': use_foxglove,
             'use_rviz': use_rviz,
             'publish_initial_configuration': 'false',
+            'publish_ground_truth_tf': publish_ground_truth_tf,
         }.items(),
     )
     example_controller = Node(
@@ -30,15 +35,26 @@ def generate_launch_description():
         executable='example_stance_controller',
         name='example_stance_controller',
         output='screen',
+        parameters=[{
+            'use_sim_time': ParameterValue(use_sim_time, value_type=bool),
+        }],
     )
     interface_monitor = Node(
         package='robot_simulation',
         executable='state_interface_monitor',
         name='state_interface_monitor',
         output='screen',
+        parameters=[{
+            'use_sim_time': ParameterValue(use_sim_time, value_type=bool),
+        }],
     )
 
     return LaunchDescription([
+        DeclareLaunchArgument(
+            'use_sim_time',
+            default_value='true',
+            description='Use the simulator fixed-step clock for experiment nodes.',
+        ),
         DeclareLaunchArgument(
             'use_foxglove',
             default_value='true',
@@ -48,6 +64,11 @@ def generate_launch_description():
             'use_rviz',
             default_value='false',
             description='Start RViz (requires a graphical display).',
+        ),
+        DeclareLaunchArgument(
+            'publish_ground_truth_tf',
+            default_value='false',
+            description='Publish optional truth TF in distinct sim_ground_truth frames.',
         ),
         stack,
         example_controller,

--- a/robot_ws/src/robot_simulation/launch/experiment.launch.py
+++ b/robot_ws/src/robot_simulation/launch/experiment.launch.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+
+"""Launch the deterministic PyBullet control-and-sensor teaching slice."""
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
+
+
+def generate_launch_description():
+    use_foxglove = LaunchConfiguration('use_foxglove')
+    use_rviz = LaunchConfiguration('use_rviz')
+    master_launch_file = PathJoinSubstitution(
+        [FindPackageShare('robot_simulation'), 'launch', 'master.launch.py']
+    )
+
+    stack = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(master_launch_file),
+        launch_arguments={
+            'use_foxglove': use_foxglove,
+            'use_rviz': use_rviz,
+            'publish_initial_configuration': 'false',
+        }.items(),
+    )
+    example_controller = Node(
+        package='robot_controller',
+        executable='example_stance_controller',
+        name='example_stance_controller',
+        output='screen',
+    )
+    interface_monitor = Node(
+        package='robot_simulation',
+        executable='state_interface_monitor',
+        name='state_interface_monitor',
+        output='screen',
+    )
+
+    return LaunchDescription([
+        DeclareLaunchArgument(
+            'use_foxglove',
+            default_value='true',
+            description='Start the Foxglove WebSocket bridge on port 8765.',
+        ),
+        DeclareLaunchArgument(
+            'use_rviz',
+            default_value='false',
+            description='Start RViz (requires a graphical display).',
+        ),
+        stack,
+        example_controller,
+        interface_monitor,
+    ])

--- a/robot_ws/src/robot_simulation/launch/master.launch.py
+++ b/robot_ws/src/robot_simulation/launch/master.launch.py
@@ -1,12 +1,16 @@
 #!/usr/bin/env python3
 
 from launch import LaunchDescription
-from launch.actions import IncludeLaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.substitutions import PathJoinSubstitution
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 from launch_ros.substitutions import FindPackageShare
 
+
 def generate_launch_description():
+    use_foxglove = LaunchConfiguration('use_foxglove')
+    use_rviz = LaunchConfiguration('use_rviz')
+
     visualization_launch_file = PathJoinSubstitution(
         [FindPackageShare('robot_desc'), 'launch', 'view_robot.launch.py']
     )
@@ -20,7 +24,11 @@ def generate_launch_description():
     )
 
     visualization_launch_file = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource(visualization_launch_file)
+        PythonLaunchDescriptionSource(visualization_launch_file),
+        launch_arguments={
+            'use_foxglove': use_foxglove,
+            'use_rviz': use_rviz,
+        }.items(),
     )
 
     sim_launch = IncludeLaunchDescription(
@@ -32,7 +40,17 @@ def generate_launch_description():
     )
 
     return LaunchDescription([
+        DeclareLaunchArgument(
+            'use_foxglove',
+            default_value='true',
+            description='Start the Foxglove WebSocket bridge on port 8765.',
+        ),
+        DeclareLaunchArgument(
+            'use_rviz',
+            default_value='false',
+            description='Start RViz (requires a graphical display).',
+        ),
         visualization_launch_file,
         sim_launch,
-        controller_launch
+        controller_launch,
     ])

--- a/robot_ws/src/robot_simulation/launch/master.launch.py
+++ b/robot_ws/src/robot_simulation/launch/master.launch.py
@@ -8,8 +8,10 @@ from launch_ros.substitutions import FindPackageShare
 
 
 def generate_launch_description():
+    use_sim_time = LaunchConfiguration('use_sim_time')
     use_foxglove = LaunchConfiguration('use_foxglove')
     use_rviz = LaunchConfiguration('use_rviz')
+    publish_ground_truth_tf = LaunchConfiguration('publish_ground_truth_tf')
     publish_initial_configuration = LaunchConfiguration(
         'publish_initial_configuration'
     )
@@ -29,23 +31,33 @@ def generate_launch_description():
     visualization_launch_file = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(visualization_launch_file),
         launch_arguments={
+            'use_sim_time': use_sim_time,
             'use_foxglove': use_foxglove,
             'use_rviz': use_rviz,
         }.items(),
     )
 
     sim_launch = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource(sim_launch_file)
+        PythonLaunchDescriptionSource(sim_launch_file),
+        launch_arguments={
+            'publish_ground_truth_tf': publish_ground_truth_tf,
+        }.items(),
     )
 
     controller_launch = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(controller_launch_file),
         launch_arguments={
+            'use_sim_time': use_sim_time,
             'publish_initial_configuration': publish_initial_configuration,
         }.items(),
     )
 
     return LaunchDescription([
+        DeclareLaunchArgument(
+            'use_sim_time',
+            default_value='true',
+            description='Use the simulator fixed-step clock for non-simulator nodes.',
+        ),
         DeclareLaunchArgument(
             'use_foxglove',
             default_value='true',
@@ -60,6 +72,11 @@ def generate_launch_description():
             'publish_initial_configuration',
             default_value='true',
             description='Publish the controller adapter nominal stance at startup.',
+        ),
+        DeclareLaunchArgument(
+            'publish_ground_truth_tf',
+            default_value='false',
+            description='Publish optional truth TF in distinct sim_ground_truth frames.',
         ),
         visualization_launch_file,
         sim_launch,

--- a/robot_ws/src/robot_simulation/launch/master.launch.py
+++ b/robot_ws/src/robot_simulation/launch/master.launch.py
@@ -10,6 +10,9 @@ from launch_ros.substitutions import FindPackageShare
 def generate_launch_description():
     use_foxglove = LaunchConfiguration('use_foxglove')
     use_rviz = LaunchConfiguration('use_rviz')
+    publish_initial_configuration = LaunchConfiguration(
+        'publish_initial_configuration'
+    )
 
     visualization_launch_file = PathJoinSubstitution(
         [FindPackageShare('robot_desc'), 'launch', 'view_robot.launch.py']
@@ -36,7 +39,10 @@ def generate_launch_description():
     )
 
     controller_launch = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource(controller_launch_file)
+        PythonLaunchDescriptionSource(controller_launch_file),
+        launch_arguments={
+            'publish_initial_configuration': publish_initial_configuration,
+        }.items(),
     )
 
     return LaunchDescription([
@@ -49,6 +55,11 @@ def generate_launch_description():
             'use_rviz',
             default_value='false',
             description='Start RViz (requires a graphical display).',
+        ),
+        DeclareLaunchArgument(
+            'publish_initial_configuration',
+            default_value='true',
+            description='Publish the controller adapter nominal stance at startup.',
         ),
         visualization_launch_file,
         sim_launch,

--- a/robot_ws/src/robot_simulation/launch/start_sim.launch.py
+++ b/robot_ws/src/robot_simulation/launch/start_sim.launch.py
@@ -1,20 +1,17 @@
 #!/usr/bin/env python3
 
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument
-from launch.substitutions import Command, FindExecutable, LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import Node
-from launch_ros.substitutions import FindPackageShare
+
 
 def generate_launch_description():
-    
     sim_launch = Node(
         package='robot_simulation',
         executable='quad_sim',
         name='quad_sim',
-        output='screen'
+        output='screen',
     )
-    
+
     return LaunchDescription([
-        sim_launch
+        sim_launch,
     ])

--- a/robot_ws/src/robot_simulation/launch/start_sim.launch.py
+++ b/robot_ws/src/robot_simulation/launch/start_sim.launch.py
@@ -1,17 +1,33 @@
 #!/usr/bin/env python3
 
 from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
+from launch_ros.parameter_descriptions import ParameterValue
 
 
 def generate_launch_description():
+    publish_ground_truth_tf = LaunchConfiguration('publish_ground_truth_tf')
     sim_launch = Node(
         package='robot_simulation',
         executable='quad_sim',
         name='quad_sim',
         output='screen',
+        parameters=[{
+            'use_sim_time': False,
+            'publish_ground_truth_tf': ParameterValue(
+                publish_ground_truth_tf,
+                value_type=bool,
+            ),
+        }],
     )
 
     return LaunchDescription([
+        DeclareLaunchArgument(
+            'publish_ground_truth_tf',
+            default_value='false',
+            description='Publish optional truth TF in distinct sim_ground_truth frames.',
+        ),
         sim_launch,
     ])

--- a/robot_ws/src/robot_simulation/package.xml
+++ b/robot_ws/src/robot_simulation/package.xml
@@ -2,10 +2,25 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>robot_simulation</name>
-  <version>0.0.0</version>
-  <description>Quadruped Simulation in Pybullet package</description>
-  <maintainer email="mahussein04@gmail.com">mahus</maintainer>
-  <license>TODO: License declaration</license>
+  <version>0.1.0</version>
+  <description>Headless PyBullet simulation and ROS 2 interfaces for the robot dog.</description>
+  <maintainer email="mahussein04@gmail.com">Mostafa Hussein</maintainer>
+  <license>NOASSERTION</license>
+
+  <buildtool_depend>ament_python</buildtool_depend>
+
+  <depend>ament_index_python</depend>
+  <depend>geometry_msgs</depend>
+  <depend>rclpy</depend>
+  <depend>sensor_msgs</depend>
+  <depend>tf2_ros</depend>
+
+  <exec_depend>launch</exec_depend>
+  <exec_depend>launch_ros</exec_depend>
+  <exec_depend>python3-numpy</exec_depend>
+  <exec_depend>python3-scipy</exec_depend>
+  <exec_depend>robot_controller</exec_depend>
+  <exec_depend>robot_desc</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/robot_ws/src/robot_simulation/package.xml
+++ b/robot_ws/src/robot_simulation/package.xml
@@ -11,6 +11,7 @@
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>rclpy</depend>
+  <depend>rosgraph_msgs</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
   <depend>tf2_ros</depend>

--- a/robot_ws/src/robot_simulation/package.xml
+++ b/robot_ws/src/robot_simulation/package.xml
@@ -3,14 +3,16 @@
 <package format="3">
   <name>robot_simulation</name>
   <version>0.1.0</version>
-  <description>Headless PyBullet simulation and ROS 2 interfaces for the robot dog.</description>
+  <description>Deterministic PyBullet simulation and idealized ROS 2 teaching sensors.</description>
   <maintainer email="mahussein04@gmail.com">Mostafa Hussein</maintainer>
   <license>NOASSERTION</license>
 
   <depend>ament_index_python</depend>
   <depend>geometry_msgs</depend>
+  <depend>nav_msgs</depend>
   <depend>rclpy</depend>
   <depend>sensor_msgs</depend>
+  <depend>std_msgs</depend>
   <depend>tf2_ros</depend>
 
   <exec_depend>launch</exec_depend>

--- a/robot_ws/src/robot_simulation/package.xml
+++ b/robot_ws/src/robot_simulation/package.xml
@@ -7,8 +7,6 @@
   <maintainer email="mahussein04@gmail.com">Mostafa Hussein</maintainer>
   <license>NOASSERTION</license>
 
-  <buildtool_depend>ament_python</buildtool_depend>
-
   <depend>ament_index_python</depend>
   <depend>geometry_msgs</depend>
   <depend>rclpy</depend>

--- a/robot_ws/src/robot_simulation/robot_simulation/pybullet_sim.py
+++ b/robot_ws/src/robot_simulation/robot_simulation/pybullet_sim.py
@@ -11,6 +11,8 @@ import pybullet as p
 import pybullet_data
 import rclpy
 from rclpy.node import Node
+from rclpy.time import Time
+from rosgraph_msgs.msg import Clock
 from scipy.spatial.transform import Rotation
 from sensor_msgs.msg import Imu, JointState
 from std_msgs.msg import Bool, Float64
@@ -18,18 +20,35 @@ from tf2_ros import TransformBroadcaster
 
 
 GRAVITY_WORLD = np.asarray([0.0, 0.0, -9.81])
+TIME_STEP_NANOSECONDS = 10_000_000
+TIME_STEP_SECONDS = TIME_STEP_NANOSECONDS / 1_000_000_000
 INERTIAL_OFFSET = np.asarray([
     -0.008382264142625067,
     -1.4798434925308436e-05,
     0.030113658418836745,
 ])
-REVERSED_JOINT_INDICES = {1, 3, 4, 8, 9}
+JOINT_DIRECTION_BY_NAME = {
+    'Revolute_1': 1.0,
+    'Revolute_3': -1.0,
+    'Revolute_4': 1.0,
+    'Revolute_5': -1.0,
+    'Revolute_20': -1.0,
+    'Revolute_23': 1.0,
+    'Revolute_25': 1.0,
+    'Revolute_31': 1.0,
+    'Revolute_35': -1.0,
+    'Revolute_40': -1.0,
+    'Revolute_45': 1.0,
+    'Revolute_48': 1.0,
+}
 FOOT_LINK_NAMES = {
     'front_left': 'Component1_Mirror___5__1',
     'front_right': 'Foot_v3_2',
     'rear_left': 'Component1_Mirror___5__2',
     'rear_right': 'Foot_v3_1',
 }
+GROUND_TRUTH_WORLD_FRAME = 'sim_ground_truth_world'
+GROUND_TRUTH_BASE_FRAME = 'sim_ground_truth_base_link'
 
 
 def euler_to_quaternion(euler_angles):
@@ -47,15 +66,28 @@ def inverse_rotate_vector(quaternion, vector):
     return Rotation.from_quat(quaternion).inv().apply(np.asarray(vector))
 
 
+def simulation_timestamp(step_count):
+    """Return the exact ROS timestamp for a fixed-step simulation index."""
+    if step_count < 0:
+        raise ValueError('step_count must be non-negative')
+    return Time(nanoseconds=step_count * TIME_STEP_NANOSECONDS).to_msg()
+
+
 class QuadSim(Node):
     """Expose PyBullet commands, idealized sensors, and separate ground truth."""
 
     def __init__(self):
         super().__init__('quadruped_sim')
 
-        self.time_step = 0.01
+        self.time_step = TIME_STEP_SECONDS
+        self.step_count = 0
+        self.declare_parameter('publish_ground_truth_tf', False)
         self.client = self._initialize_simulation()
-        self.joint_name_to_index, self.link_name_to_index = self._index_model()
+        (
+            self.joint_name_to_index,
+            self.joint_index_to_name,
+            self.link_name_to_index,
+        ) = self._index_model()
         self.foot_link_indices = {
             foot: self.link_name_to_index[link_name]
             for foot, link_name in FOOT_LINK_NAMES.items()
@@ -74,6 +106,7 @@ class QuadSim(Node):
             '/sim/ground_truth/odom',
             10,
         )
+        self.clock_publisher = self.create_publisher(Clock, '/clock', 1)
         self.contact_flag_publishers = {}
         self.contact_normal_force_publishers = {}
         self.contact_wrench_publishers = {}
@@ -101,7 +134,9 @@ class QuadSim(Node):
             self.joint_callback,
             10,
         )
-        self.tf_broadcaster = TransformBroadcaster(self)
+        self.ground_truth_tf_broadcaster = None
+        if self.get_parameter('publish_ground_truth_tf').value:
+            self.ground_truth_tf_broadcaster = TransformBroadcaster(self)
         _position, _orientation, linear_velocity, _angular_velocity = self._base_state()
         self.previous_base_velocity_world = linear_velocity
         self.timer = self.create_timer(self.time_step, self.run_simulation)
@@ -130,6 +165,7 @@ class QuadSim(Node):
 
     def _index_model(self):
         joint_names = {}
+        joint_indices = {}
         link_names = {}
         for joint_index in range(p.getNumJoints(self.quad, physicsClientId=self.client)):
             joint_info = p.getJointInfo(
@@ -137,13 +173,23 @@ class QuadSim(Node):
                 joint_index,
                 physicsClientId=self.client,
             )
-            joint_names[joint_info[1].decode('utf-8')] = joint_index
+            joint_name = joint_info[1].decode('utf-8')
+            joint_names[joint_name] = joint_index
+            joint_indices[joint_index] = joint_name
             link_names[joint_info[12].decode('utf-8')] = joint_index
 
+        configured_joints = set(JOINT_DIRECTION_BY_NAME)
+        model_joints = set(joint_names)
+        if configured_joints != model_joints:
+            missing = sorted(model_joints - configured_joints)
+            unknown = sorted(configured_joints - model_joints)
+            raise RuntimeError(
+                f'joint direction map mismatch: missing={missing}, unknown={unknown}'
+            )
         missing_links = set(FOOT_LINK_NAMES.values()) - set(link_names)
         if missing_links:
             raise RuntimeError(f'foot links missing from PyBullet model: {sorted(missing_links)}')
-        return joint_names, link_names
+        return joint_names, joint_indices, link_names
 
     def _base_state(self):
         position, orientation = p.getBasePositionAndOrientation(
@@ -180,14 +226,17 @@ class QuadSim(Node):
             )
         p.stepSimulation(physicsClientId=self.client)
 
-        stamp = self.get_clock().now().to_msg()
+        self.step_count += 1
+        stamp = simulation_timestamp(self.step_count)
+        self.clock_publisher.publish(Clock(clock=stamp))
         base_position, orientation, linear_velocity, angular_velocity = self._base_state()
         linear_acceleration = (
             linear_velocity - self.previous_base_velocity_world
         ) / self.time_step
         self.previous_base_velocity_world = linear_velocity
 
-        self._publish_transform(stamp, base_position, orientation)
+        if self.ground_truth_tf_broadcaster is not None:
+            self._publish_ground_truth_transform(stamp, base_position, orientation)
         self._publish_joint_states(stamp)
         self._publish_imu(
             stamp,
@@ -204,11 +253,11 @@ class QuadSim(Node):
         )
         self._publish_contacts(stamp)
 
-    def _publish_transform(self, stamp, position, orientation):
+    def _publish_ground_truth_transform(self, stamp, position, orientation):
         transform = TransformStamped()
         transform.header.stamp = stamp
-        transform.header.frame_id = 'world'
-        transform.child_frame_id = 'base_link'
+        transform.header.frame_id = GROUND_TRUTH_WORLD_FRAME
+        transform.child_frame_id = GROUND_TRUTH_BASE_FRAME
         transform.transform.translation.x = position[0]
         transform.transform.translation.y = position[1]
         transform.transform.translation.z = position[2]
@@ -216,7 +265,7 @@ class QuadSim(Node):
         transform.transform.rotation.y = orientation[1]
         transform.transform.rotation.z = orientation[2]
         transform.transform.rotation.w = orientation[3]
-        self.tf_broadcaster.sendTransform(transform)
+        self.ground_truth_tf_broadcaster.sendTransform(transform)
 
     def _publish_joint_states(self, stamp):
         message = JointState()
@@ -271,8 +320,8 @@ class QuadSim(Node):
     ):
         message = Odometry()
         message.header.stamp = stamp
-        message.header.frame_id = 'world'
-        message.child_frame_id = 'base_link'
+        message.header.frame_id = GROUND_TRUTH_WORLD_FRAME
+        message.child_frame_id = GROUND_TRUTH_BASE_FRAME
         message.pose.pose.position.x = position[0]
         message.pose.pose.position.y = position[1]
         message.pose.pose.position.z = position[2]
@@ -355,9 +404,8 @@ class QuadSim(Node):
             if not 0 <= joint_index < len(self.angles):
                 self.get_logger().warning(f'Ignoring out-of-range joint index {name}')
                 continue
-            self.angles[joint_index] = (
-                -position if joint_index in REVERSED_JOINT_INDICES else position
-            )
+            joint_name = self.joint_index_to_name[joint_index]
+            self.angles[joint_index] = JOINT_DIRECTION_BY_NAME[joint_name] * position
 
     def destroy_node(self):
         """Disconnect the dedicated PyBullet client before destroying the node."""

--- a/robot_ws/src/robot_simulation/robot_simulation/pybullet_sim.py
+++ b/robot_ws/src/robot_simulation/robot_simulation/pybullet_sim.py
@@ -1,195 +1,151 @@
-import rclpy
-from rclpy.node import Node
-from sensor_msgs.msg import JointState 
-from geometry_msgs.msg import TransformStamped
-
-from tf2_ros import TransformBroadcaster
-
-import pybullet as p
-import pybullet_data
-import numpy as np
+"""Run the existing headless PyBullet quadruped simulation."""
 
 from math import pi
+from pathlib import Path
+
+from ament_index_python.packages import get_package_share_directory
+from geometry_msgs.msg import TransformStamped
+import numpy as np
+import pybullet as p
+import pybullet_data
+import rclpy
+from rclpy.node import Node
 from scipy.spatial.transform import Rotation
-
-def quat_2_mat(q):
-  rot = Rotation.from_quat(q)
-  rot_mat = rot.as_matrix()
-  
-  return rot_mat
-
-def eular_2_quat(eular):
-  rot = Rotation.from_euler("xyz", eular)
-  quat = rot.as_quat()
-
-  return quat
-
-def eular_2_mat(eular):
-  rot = Rotation.from_euler("xyz", eular)
-  rot_mat = rot.as_matrix()
-
-  return rot_mat
-
-def quat_rot(q, vec):
-  rot = Rotation.from_quat(q)
-  return rot.apply(np.array(vec))
- 
-class Quad_Sim(Node):
-  def __init__(self):
-    super().__init__('quadruped_sim')
-      
-    # Create a publisher
-    self.pub = self.create_publisher(JointState, "/joint_states", 10)
-    self.time_step = 0.01
-    self.sim_init()
-    self.timer = self.create_timer(self.time_step, self.run_sim)
-    self.tf_broadcaster = TransformBroadcaster(self)
-    
-    self.angles = [0,0,0,0,0,0,0,0,0,0,0,0]
-
-    self.cmd_sub = self.create_subscription(
-       JointState,
-       "/cmd_jnts",
-       self.joint_callback,
-       10
-    )
-    self.cmd_sub # prevents unused variable warning
-      
-
-  def sim_init(self):
-    # Start sim (headless)
-    self.client = p.connect(p.DIRECT)
-
-    # Set Gravity
-    p.setGravity(0,0,-9.81, physicsClientId=self.client)
-
-    # Set timestep
-    p.setTimeStep(self.time_step, self.client)
-
-    # Add a plane
-    # TODO: Change this with environment in the future (make modular)
-    p.setAdditionalSearchPath(pybullet_data.getDataPath())
-    plane = p.loadURDF("plane.urdf")
-
-    # Load robot URDF
-    # TODO: use full leg (implement closed chain kinematics)
-    quad_urdf = "./install/robot_simulation/share/robot_simulation/urdf/robot_core.xacro"
-    startPos = [0,0,1]
-    startRot_eular = [0,0,pi]
-    startRot_quat = eular_2_quat(startRot_eular)
-    self.startRot_mat = eular_2_mat(startRot_eular)
-    quad_flags = p.URDF_USE_SELF_COLLISION | p.URDF_USE_INERTIA_FROM_FILE # enable self collisions and add calculated inertias from urdf
-    self.quad = p.loadURDF(quad_urdf, basePosition = startPos, baseOrientation = startRot_quat, flags = quad_flags)
-
-    # TODO: close kinematic chains in legs
-
-    # TODO: Debug hidden meshes
-
-    # TODO: create a topic for joint control commands
-    # Sliders for temporary control
-    self.num_joints = p.getNumJoints(self.quad)
-
-  def run_sim(self):
-    # Get updated position and orientation of the quad
-    position, orinetation = p.getBasePositionAndOrientation(self.quad)
-    
-    inertial_offset = [-0.008382264142625067,-1.4798434925308436e-05,0.030113658418836745]
-    pos_offset = quat_rot(np.array(orinetation), inertial_offset)
-    pos = np.array(position) - pos_offset
-
-    t = TransformStamped()
-
-    t.header.stamp = self.get_clock().now().to_msg()
-    t.header.frame_id = "world"
-    t.child_frame_id = "base_link"
-    t.transform.translation.x = pos[0]
-    t.transform.translation.y = pos[1]
-    t.transform.translation.z = pos[2]
-    t.transform.rotation.x = orinetation[0]
-    t.transform.rotation.y = orinetation[1]
-    t.transform.rotation.z = orinetation[2]
-    t.transform.rotation.w = orinetation[3]
-
-    self.tf_broadcaster.sendTransform(t)
-
-    # Initialize joint state message to publish
-    msg = JointState()
-
-    for i in range(self.num_joints):
-        # Update teh commanded joint angles from the sliders for temporary control
-        angle = self.angles[i]
-        p.setJointMotorControl2(self.quad, i, p.POSITION_CONTROL, targetPosition = angle)
-
-        # Update current joint's state to be sent as part 
-        # of the joint state msg being publishd
-        name = p.getJointInfo(self.quad, i, self.client)[1]
-        msg.name.append(name.decode("utf-8")) # decode name from bytes to utf-8
-        angle_pos,velocity,reactions,effort = p.getJointState(self.quad, i, self.client)
-        msg.position.append(angle_pos)
-        msg.velocity.append(velocity)
-        msg.effort.append(effort)
-
-    msg.header.stamp = self.get_clock().now().to_msg()
-    self.pub.publish(msg)
-
-    # Get Quad Rotation Matrix
-    rotMat = quat_2_mat(orinetation) @ self.startRot_mat
-    position = list(position)
-
-    # Set up axes for the camera to be the quad reference
-    # frame's z-axis
-    up_axes = np.matrix([[0],[0],[1]])
-    up_axes = rotMat @ up_axes
-
-    # Set the camera's position and its target's position
-    # TODO: add global constants for cam displacment
-    # TODO: base camera target to be based on camera rotation
-    cam_displacement = np.array([0.2,0,0.05])
-    target_displacement = np.array([0.1,0,0])
-    cam_position = position.copy()
-    cam_position += rotMat @ cam_displacement
-    target_position = cam_position.copy()
-    target_position += rotMat @ target_displacement 
+from sensor_msgs.msg import JointState
+from tf2_ros import TransformBroadcaster
 
 
-    # Compute Camera view and projection matricies
-    cam_view_mat = p.computeViewMatrix (cam_position,target_position,up_axes)
-    # TODO: add global constants for fov and other info for cam proj mat
-    cam_proj_mat = p.computeProjectionMatrixFOV(53.50,1280/720,0.001,1)
-    # TODO: look into speeding up generating camera images
-    #image = p.getCameraImage(10,10,cam_view_mat,cam_proj_mat,renderer = p.ER_BULLET_HARDWARE_OPENGL,physicsClientId = self.client)
-    # TODO: publish camera images over an images topic
-    # image = np.reshape(image, (720,1280))
+def euler_to_quaternion(euler_angles):
+    """Convert XYZ Euler angles into an ``xyzw`` quaternion."""
+    return Rotation.from_euler('xyz', euler_angles).as_quat()
 
-    # Step forward in the bullet physics simulation
-    p.stepSimulation()
 
-  def joint_callback(self, msg):
-    for i in range(len(msg.name)):
-      jointNum = int(msg.name[i])
-      if jointNum == 1 or jointNum == 3 or jointNum == 4 or jointNum == 8 or jointNum == 9:
-        self.angles[jointNum] = -msg.position[jointNum]
-      else:
-        self.angles[jointNum] = msg.position[jointNum]
-    
+def rotate_vector(quaternion, vector):
+    """Rotate a vector by an ``xyzw`` quaternion."""
+    return Rotation.from_quat(quaternion).apply(np.asarray(vector))
+
+
+class QuadSim(Node):
+    """Expose the PyBullet robot state and joint commands through ROS 2."""
+
+    def __init__(self):
+        super().__init__('quadruped_sim')
+
+        self.time_step = 0.01
+        self.client = self._initialize_simulation()
+        self.angles = [0.0] * p.getNumJoints(self.quad, physicsClientId=self.client)
+
+        self.joint_state_publisher = self.create_publisher(JointState, '/joint_states', 10)
+        self.command_subscription = self.create_subscription(
+            JointState,
+            '/cmd_jnts',
+            self.joint_callback,
+            10,
+        )
+        self.tf_broadcaster = TransformBroadcaster(self)
+        self.timer = self.create_timer(self.time_step, self.run_simulation)
+
+    def _initialize_simulation(self):
+        client = p.connect(p.DIRECT)
+        p.setGravity(0, 0, -9.81, physicsClientId=client)
+        p.setTimeStep(self.time_step, physicsClientId=client)
+
+        p.setAdditionalSearchPath(pybullet_data.getDataPath(), physicsClientId=client)
+        p.loadURDF('plane.urdf', physicsClientId=client)
+
+        package_share = Path(get_package_share_directory('robot_simulation'))
+        quad_urdf = package_share / 'urdf' / 'robot_core.xacro'
+        start_orientation = euler_to_quaternion([0, 0, pi])
+        flags = p.URDF_USE_SELF_COLLISION | p.URDF_USE_INERTIA_FROM_FILE
+        self.quad = p.loadURDF(
+            str(quad_urdf),
+            basePosition=[0, 0, 1],
+            baseOrientation=start_orientation,
+            flags=flags,
+            physicsClientId=client,
+        )
+
+        return client
+
+    def run_simulation(self):
+        """Advance PyBullet once and publish the resulting ROS state."""
+        position, orientation = p.getBasePositionAndOrientation(
+            self.quad,
+            physicsClientId=self.client,
+        )
+
+        inertial_offset = [-0.008382264142625067, -1.4798434925308436e-05,
+                           0.030113658418836745]
+        base_position = np.asarray(position) - rotate_vector(orientation, inertial_offset)
+
+        transform = TransformStamped()
+        transform.header.stamp = self.get_clock().now().to_msg()
+        transform.header.frame_id = 'world'
+        transform.child_frame_id = 'base_link'
+        transform.transform.translation.x = base_position[0]
+        transform.transform.translation.y = base_position[1]
+        transform.transform.translation.z = base_position[2]
+        transform.transform.rotation.x = orientation[0]
+        transform.transform.rotation.y = orientation[1]
+        transform.transform.rotation.z = orientation[2]
+        transform.transform.rotation.w = orientation[3]
+        self.tf_broadcaster.sendTransform(transform)
+
+        message = JointState()
+        message.header.stamp = transform.header.stamp
+        for joint_index, target_angle in enumerate(self.angles):
+            p.setJointMotorControl2(
+                self.quad,
+                joint_index,
+                p.POSITION_CONTROL,
+                targetPosition=target_angle,
+                physicsClientId=self.client,
+            )
+            joint_name = p.getJointInfo(
+                self.quad,
+                joint_index,
+                physicsClientId=self.client,
+            )[1]
+            angle, velocity, _reactions, effort = p.getJointState(
+                self.quad,
+                joint_index,
+                physicsClientId=self.client,
+            )
+            message.name.append(joint_name.decode('utf-8'))
+            message.position.append(angle)
+            message.velocity.append(velocity)
+            message.effort.append(effort)
+
+        self.joint_state_publisher.publish(message)
+        p.stepSimulation(physicsClientId=self.client)
+
+    def joint_callback(self, message):
+        """Apply indexed joint commands from the controller adapter."""
+        reversed_joints = {1, 3, 4, 8, 9}
+        for name, position in zip(message.name, message.position):
+            joint_index = int(name)
+            if not 0 <= joint_index < len(self.angles):
+                self.get_logger().warning('Ignoring out-of-range joint index %s', name)
+                continue
+            self.angles[joint_index] = -position if joint_index in reversed_joints else position
+
+    def destroy_node(self):
+        """Disconnect the dedicated PyBullet client before destroying the node."""
+        if p.isConnected(self.client):
+            p.disconnect(physicsClientId=self.client)
+        return super().destroy_node()
+
+
 def main(args=None):
-  
-    # Initialize the rclpy library
+    """Start the ROS 2 PyBullet simulation node."""
     rclpy.init(args=args)
+    simulator = QuadSim()
+    try:
+        rclpy.spin(simulator)
+    finally:
+        simulator.destroy_node()
+        rclpy.shutdown()
 
-    # Create the node
-    quad_sim = Quad_Sim()
 
-    # Spin the node so the callback function is called.
-    rclpy.spin(quad_sim)
-
-    # Destroy the node explicitly
-    # (optional - otherwise it will be done automatically
-    # when the garbage collector destroys the node object)
-    quad_sim.destroy_node()
-
-    # Shutdown the ROS client library for Python
-    rclpy.shutdown()
-  
 if __name__ == '__main__':
-  main()
+    main()

--- a/robot_ws/src/robot_simulation/robot_simulation/pybullet_sim.py
+++ b/robot_ws/src/robot_simulation/robot_simulation/pybullet_sim.py
@@ -1,18 +1,35 @@
-"""Run the existing headless PyBullet quadruped simulation."""
+"""Run the headless PyBullet quadruped and publish teaching interfaces."""
 
 from math import pi
 from pathlib import Path
 
 from ament_index_python.packages import get_package_share_directory
-from geometry_msgs.msg import TransformStamped
+from geometry_msgs.msg import TransformStamped, WrenchStamped
+from nav_msgs.msg import Odometry
 import numpy as np
 import pybullet as p
 import pybullet_data
 import rclpy
 from rclpy.node import Node
 from scipy.spatial.transform import Rotation
-from sensor_msgs.msg import JointState
+from sensor_msgs.msg import Imu, JointState
+from std_msgs.msg import Bool, Float64
 from tf2_ros import TransformBroadcaster
+
+
+GRAVITY_WORLD = np.asarray([0.0, 0.0, -9.81])
+INERTIAL_OFFSET = np.asarray([
+    -0.008382264142625067,
+    -1.4798434925308436e-05,
+    0.030113658418836745,
+])
+REVERSED_JOINT_INDICES = {1, 3, 4, 8, 9}
+FOOT_LINK_NAMES = {
+    'front_left': 'Component1_Mirror___5__1',
+    'front_right': 'Foot_v3_2',
+    'rear_left': 'Component1_Mirror___5__2',
+    'rear_right': 'Foot_v3_1',
+}
 
 
 def euler_to_quaternion(euler_angles):
@@ -21,21 +38,63 @@ def euler_to_quaternion(euler_angles):
 
 
 def rotate_vector(quaternion, vector):
-    """Rotate a vector by an ``xyzw`` quaternion."""
+    """Rotate a vector from base coordinates into world coordinates."""
     return Rotation.from_quat(quaternion).apply(np.asarray(vector))
 
 
+def inverse_rotate_vector(quaternion, vector):
+    """Rotate a vector from world coordinates into base coordinates."""
+    return Rotation.from_quat(quaternion).inv().apply(np.asarray(vector))
+
+
 class QuadSim(Node):
-    """Expose the PyBullet robot state and joint commands through ROS 2."""
+    """Expose PyBullet commands, idealized sensors, and separate ground truth."""
 
     def __init__(self):
         super().__init__('quadruped_sim')
 
         self.time_step = 0.01
         self.client = self._initialize_simulation()
+        self.joint_name_to_index, self.link_name_to_index = self._index_model()
+        self.foot_link_indices = {
+            foot: self.link_name_to_index[link_name]
+            for foot, link_name in FOOT_LINK_NAMES.items()
+        }
         self.angles = [0.0] * p.getNumJoints(self.quad, physicsClientId=self.client)
 
         self.joint_state_publisher = self.create_publisher(JointState, '/joint_states', 10)
+        self.sim_joint_state_publisher = self.create_publisher(
+            JointState,
+            '/sim/sensors/joint_states',
+            10,
+        )
+        self.imu_publisher = self.create_publisher(Imu, '/sim/sensors/imu', 10)
+        self.ground_truth_publisher = self.create_publisher(
+            Odometry,
+            '/sim/ground_truth/odom',
+            10,
+        )
+        self.contact_flag_publishers = {}
+        self.contact_normal_force_publishers = {}
+        self.contact_wrench_publishers = {}
+        for foot in FOOT_LINK_NAMES:
+            sensor_prefix = f'/sim/sensors/foot_contacts/{foot}'
+            self.contact_flag_publishers[foot] = self.create_publisher(
+                Bool,
+                sensor_prefix,
+                10,
+            )
+            self.contact_normal_force_publishers[foot] = self.create_publisher(
+                Float64,
+                f'{sensor_prefix}/normal_force',
+                10,
+            )
+            self.contact_wrench_publishers[foot] = self.create_publisher(
+                WrenchStamped,
+                f'{sensor_prefix}/wrench',
+                10,
+            )
+
         self.command_subscription = self.create_subscription(
             JointState,
             '/cmd_jnts',
@@ -43,15 +102,17 @@ class QuadSim(Node):
             10,
         )
         self.tf_broadcaster = TransformBroadcaster(self)
+        _position, _orientation, linear_velocity, _angular_velocity = self._base_state()
+        self.previous_base_velocity_world = linear_velocity
         self.timer = self.create_timer(self.time_step, self.run_simulation)
 
     def _initialize_simulation(self):
         client = p.connect(p.DIRECT)
-        p.setGravity(0, 0, -9.81, physicsClientId=client)
+        p.setGravity(*GRAVITY_WORLD, physicsClientId=client)
         p.setTimeStep(self.time_step, physicsClientId=client)
 
         p.setAdditionalSearchPath(pybullet_data.getDataPath(), physicsClientId=client)
-        p.loadURDF('plane.urdf', physicsClientId=client)
+        self.plane = p.loadURDF('plane.urdf', physicsClientId=client)
 
         package_share = Path(get_package_share_directory('robot_simulation'))
         quad_urdf = package_share / 'urdf' / 'robot_core.xacro'
@@ -67,32 +128,48 @@ class QuadSim(Node):
 
         return client
 
-    def run_simulation(self):
-        """Advance PyBullet once and publish the resulting ROS state."""
+    def _index_model(self):
+        joint_names = {}
+        link_names = {}
+        for joint_index in range(p.getNumJoints(self.quad, physicsClientId=self.client)):
+            joint_info = p.getJointInfo(
+                self.quad,
+                joint_index,
+                physicsClientId=self.client,
+            )
+            joint_names[joint_info[1].decode('utf-8')] = joint_index
+            link_names[joint_info[12].decode('utf-8')] = joint_index
+
+        missing_links = set(FOOT_LINK_NAMES.values()) - set(link_names)
+        if missing_links:
+            raise RuntimeError(f'foot links missing from PyBullet model: {sorted(missing_links)}')
+        return joint_names, link_names
+
+    def _base_state(self):
         position, orientation = p.getBasePositionAndOrientation(
             self.quad,
             physicsClientId=self.client,
         )
+        linear_com_velocity, angular_velocity = p.getBaseVelocity(
+            self.quad,
+            physicsClientId=self.client,
+        )
+        orientation = np.asarray(orientation)
+        offset_world = rotate_vector(orientation, INERTIAL_OFFSET)
+        base_position = np.asarray(position) - offset_world
+        base_velocity = np.asarray(linear_com_velocity) - np.cross(
+            angular_velocity,
+            offset_world,
+        )
+        return (
+            base_position,
+            orientation,
+            base_velocity,
+            np.asarray(angular_velocity),
+        )
 
-        inertial_offset = [-0.008382264142625067, -1.4798434925308436e-05,
-                           0.030113658418836745]
-        base_position = np.asarray(position) - rotate_vector(orientation, inertial_offset)
-
-        transform = TransformStamped()
-        transform.header.stamp = self.get_clock().now().to_msg()
-        transform.header.frame_id = 'world'
-        transform.child_frame_id = 'base_link'
-        transform.transform.translation.x = base_position[0]
-        transform.transform.translation.y = base_position[1]
-        transform.transform.translation.z = base_position[2]
-        transform.transform.rotation.x = orientation[0]
-        transform.transform.rotation.y = orientation[1]
-        transform.transform.rotation.z = orientation[2]
-        transform.transform.rotation.w = orientation[3]
-        self.tf_broadcaster.sendTransform(transform)
-
-        message = JointState()
-        message.header.stamp = transform.header.stamp
+    def run_simulation(self):
+        """Advance PyBullet by one fixed step and publish the resulting state."""
         for joint_index, target_angle in enumerate(self.angles):
             p.setJointMotorControl2(
                 self.quad,
@@ -101,33 +178,186 @@ class QuadSim(Node):
                 targetPosition=target_angle,
                 physicsClientId=self.client,
             )
-            joint_name = p.getJointInfo(
+        p.stepSimulation(physicsClientId=self.client)
+
+        stamp = self.get_clock().now().to_msg()
+        base_position, orientation, linear_velocity, angular_velocity = self._base_state()
+        linear_acceleration = (
+            linear_velocity - self.previous_base_velocity_world
+        ) / self.time_step
+        self.previous_base_velocity_world = linear_velocity
+
+        self._publish_transform(stamp, base_position, orientation)
+        self._publish_joint_states(stamp)
+        self._publish_imu(
+            stamp,
+            orientation,
+            angular_velocity,
+            linear_acceleration,
+        )
+        self._publish_ground_truth(
+            stamp,
+            base_position,
+            orientation,
+            linear_velocity,
+            angular_velocity,
+        )
+        self._publish_contacts(stamp)
+
+    def _publish_transform(self, stamp, position, orientation):
+        transform = TransformStamped()
+        transform.header.stamp = stamp
+        transform.header.frame_id = 'world'
+        transform.child_frame_id = 'base_link'
+        transform.transform.translation.x = position[0]
+        transform.transform.translation.y = position[1]
+        transform.transform.translation.z = position[2]
+        transform.transform.rotation.x = orientation[0]
+        transform.transform.rotation.y = orientation[1]
+        transform.transform.rotation.z = orientation[2]
+        transform.transform.rotation.w = orientation[3]
+        self.tf_broadcaster.sendTransform(transform)
+
+    def _publish_joint_states(self, stamp):
+        message = JointState()
+        message.header.stamp = stamp
+        for joint_index in range(len(self.angles)):
+            joint_info = p.getJointInfo(
                 self.quad,
                 joint_index,
                 physicsClientId=self.client,
-            )[1]
+            )
             angle, velocity, _reactions, effort = p.getJointState(
                 self.quad,
                 joint_index,
                 physicsClientId=self.client,
             )
-            message.name.append(joint_name.decode('utf-8'))
+            message.name.append(joint_info[1].decode('utf-8'))
             message.position.append(angle)
             message.velocity.append(velocity)
             message.effort.append(effort)
 
         self.joint_state_publisher.publish(message)
-        p.stepSimulation(physicsClientId=self.client)
+        self.sim_joint_state_publisher.publish(message)
+
+    def _publish_imu(self, stamp, orientation, angular_velocity, linear_acceleration):
+        message = Imu()
+        message.header.stamp = stamp
+        message.header.frame_id = 'base_link'
+        message.orientation.x = orientation[0]
+        message.orientation.y = orientation[1]
+        message.orientation.z = orientation[2]
+        message.orientation.w = orientation[3]
+
+        angular_velocity_body = inverse_rotate_vector(orientation, angular_velocity)
+        message.angular_velocity.x = angular_velocity_body[0]
+        message.angular_velocity.y = angular_velocity_body[1]
+        message.angular_velocity.z = angular_velocity_body[2]
+
+        specific_force_world = linear_acceleration - GRAVITY_WORLD
+        specific_force_body = inverse_rotate_vector(orientation, specific_force_world)
+        message.linear_acceleration.x = specific_force_body[0]
+        message.linear_acceleration.y = specific_force_body[1]
+        message.linear_acceleration.z = specific_force_body[2]
+        self.imu_publisher.publish(message)
+
+    def _publish_ground_truth(
+        self,
+        stamp,
+        position,
+        orientation,
+        linear_velocity,
+        angular_velocity,
+    ):
+        message = Odometry()
+        message.header.stamp = stamp
+        message.header.frame_id = 'world'
+        message.child_frame_id = 'base_link'
+        message.pose.pose.position.x = position[0]
+        message.pose.pose.position.y = position[1]
+        message.pose.pose.position.z = position[2]
+        message.pose.pose.orientation.x = orientation[0]
+        message.pose.pose.orientation.y = orientation[1]
+        message.pose.pose.orientation.z = orientation[2]
+        message.pose.pose.orientation.w = orientation[3]
+
+        linear_velocity_body = inverse_rotate_vector(orientation, linear_velocity)
+        angular_velocity_body = inverse_rotate_vector(orientation, angular_velocity)
+        message.twist.twist.linear.x = linear_velocity_body[0]
+        message.twist.twist.linear.y = linear_velocity_body[1]
+        message.twist.twist.linear.z = linear_velocity_body[2]
+        message.twist.twist.angular.x = angular_velocity_body[0]
+        message.twist.twist.angular.y = angular_velocity_body[1]
+        message.twist.twist.angular.z = angular_velocity_body[2]
+        self.ground_truth_publisher.publish(message)
+
+    def _publish_contacts(self, stamp):
+        for foot, link_index in self.foot_link_indices.items():
+            contact_points = p.getContactPoints(
+                bodyA=self.quad,
+                bodyB=self.plane,
+                linkIndexA=link_index,
+                physicsClientId=self.client,
+            )
+            normal_force = 0.0
+            force_world = np.zeros(3)
+            torque_world = np.zeros(3)
+            link_state = p.getLinkState(
+                self.quad,
+                link_index,
+                computeForwardKinematics=True,
+                physicsClientId=self.client,
+            )
+            link_origin_world = np.asarray(link_state[4])
+            link_orientation_world = np.asarray(link_state[5])
+            for contact in contact_points:
+                contact_force = (
+                    np.asarray(contact[7]) * contact[9]
+                    + np.asarray(contact[11]) * contact[10]
+                    + np.asarray(contact[13]) * contact[12]
+                )
+                normal_force += contact[9]
+                force_world += contact_force
+                lever_arm = np.asarray(contact[5]) - link_origin_world
+                torque_world += np.cross(lever_arm, contact_force)
+
+            force_link = inverse_rotate_vector(link_orientation_world, force_world)
+            torque_link = inverse_rotate_vector(link_orientation_world, torque_world)
+
+            self.contact_flag_publishers[foot].publish(
+                Bool(data=normal_force > 0.0)
+            )
+            self.contact_normal_force_publishers[foot].publish(
+                Float64(data=float(normal_force))
+            )
+            wrench = WrenchStamped()
+            wrench.header.stamp = stamp
+            wrench.header.frame_id = FOOT_LINK_NAMES[foot]
+            wrench.wrench.force.x = force_link[0]
+            wrench.wrench.force.y = force_link[1]
+            wrench.wrench.force.z = force_link[2]
+            wrench.wrench.torque.x = torque_link[0]
+            wrench.wrench.torque.y = torque_link[1]
+            wrench.wrench.torque.z = torque_link[2]
+            self.contact_wrench_publishers[foot].publish(wrench)
 
     def joint_callback(self, message):
-        """Apply indexed joint commands from the controller adapter."""
-        reversed_joints = {1, 3, 4, 8, 9}
+        """Apply semantic joint-name commands, with numeric legacy fallback."""
         for name, position in zip(message.name, message.position):
-            joint_index = int(name)
+            joint_index = self.joint_name_to_index.get(name)
+            if joint_index is None:
+                try:
+                    joint_index = int(name)
+                except ValueError:
+                    self.get_logger().warning(f'Ignoring unknown joint name {name}')
+                    continue
+
             if not 0 <= joint_index < len(self.angles):
-                self.get_logger().warning('Ignoring out-of-range joint index %s', name)
+                self.get_logger().warning(f'Ignoring out-of-range joint index {name}')
                 continue
-            self.angles[joint_index] = -position if joint_index in reversed_joints else position
+            self.angles[joint_index] = (
+                -position if joint_index in REVERSED_JOINT_INDICES else position
+            )
 
     def destroy_node(self):
         """Disconnect the dedicated PyBullet client before destroying the node."""

--- a/robot_ws/src/robot_simulation/robot_simulation/state_interface_monitor.py
+++ b/robot_ws/src/robot_simulation/robot_simulation/state_interface_monitor.py
@@ -1,0 +1,120 @@
+"""Example subscriber that checks the PyBullet teaching interfaces together."""
+
+from functools import partial
+
+from geometry_msgs.msg import WrenchStamped
+from nav_msgs.msg import Odometry
+import rclpy
+from rclpy.node import Node
+from sensor_msgs.msg import Imu, JointState
+from std_msgs.msg import Bool, Float64
+
+
+FEET = ('front_left', 'front_right', 'rear_left', 'rear_right')
+
+
+class StateInterfaceMonitor(Node):
+    """Publish readiness after observing commands and every teaching topic."""
+
+    def __init__(self):
+        super().__init__('state_interface_monitor')
+        self.received = set()
+        self.contact_states = {foot: False for foot in FEET}
+        self.normal_forces = {foot: 0.0 for foot in FEET}
+        self.command_joint_names = set()
+        self.sensor_joint_names = set()
+        self.base_height = 0.0
+        self.logged_ready = False
+        self.input_subscriptions = []
+
+        self._subscribe(JointState, '/control_inputs', 'control_input')
+        self._subscribe(JointState, '/cmd_jnts', 'joint_command')
+        self._subscribe(Imu, '/sim/sensors/imu', 'imu')
+        self._subscribe(JointState, '/sim/sensors/joint_states', 'joint_states')
+        self._subscribe(Odometry, '/sim/ground_truth/odom', 'ground_truth')
+        for foot in FEET:
+            prefix = f'/sim/sensors/foot_contacts/{foot}'
+            self._subscribe(Bool, prefix, f'contact:{foot}')
+            self._subscribe(Float64, f'{prefix}/normal_force', f'normal_force:{foot}')
+            self._subscribe(WrenchStamped, f'{prefix}/wrench', f'wrench:{foot}')
+
+        self.expected = {
+            'control_input',
+            'joint_command',
+            'imu',
+            'joint_states',
+            'ground_truth',
+        }
+        for foot in FEET:
+            self.expected.update({
+                f'contact:{foot}',
+                f'normal_force:{foot}',
+                f'wrench:{foot}',
+            })
+
+        self.ready_publisher = self.create_publisher(
+            Bool,
+            '/sim/experiment/ready',
+            10,
+        )
+        self.timer = self.create_timer(0.25, self.publish_status)
+
+    def _subscribe(self, message_type, topic, key):
+        subscription = self.create_subscription(
+            message_type,
+            topic,
+            partial(self._mark_received, key),
+            10,
+        )
+        self.input_subscriptions.append(subscription)
+
+    def _mark_received(self, key, message):
+        self.received.add(key)
+        if key == 'ground_truth':
+            self.base_height = message.pose.pose.position.z
+        elif key == 'joint_command':
+            self.command_joint_names = set(message.name)
+        elif key == 'joint_states':
+            self.sensor_joint_names = set(message.name)
+        elif key.startswith('contact:'):
+            self.contact_states[key.split(':', maxsplit=1)[1]] = message.data
+        elif key.startswith('normal_force:'):
+            self.normal_forces[key.split(':', maxsplit=1)[1]] = message.data
+
+    def publish_status(self):
+        """Publish whether a coherent sample has arrived from every interface."""
+        joint_names_match = (
+            len(self.command_joint_names) == 12
+            and self.command_joint_names == self.sensor_joint_names
+        )
+        has_ground_contact = any(force > 0.0 for force in self.normal_forces.values())
+        ready = (
+            self.expected.issubset(self.received)
+            and joint_names_match
+            and has_ground_contact
+        )
+        self.ready_publisher.publish(Bool(data=ready))
+        if ready and not self.logged_ready:
+            contact_count = sum(self.contact_states.values())
+            total_normal_force = sum(self.normal_forces.values())
+            self.get_logger().info(
+                f'Teaching interfaces ready: base height {self.base_height:.3f} m, '
+                f'{contact_count} feet in contact, '
+                f'{total_normal_force:.2f} N total normal force'
+            )
+            self.logged_ready = True
+
+
+def main(args=None):
+    """Start the example state-interface monitor."""
+    rclpy.init(args=args)
+    monitor = StateInterfaceMonitor()
+    try:
+        rclpy.spin(monitor)
+    finally:
+        monitor.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/robot_ws/src/robot_simulation/robot_simulation/state_interface_monitor.py
+++ b/robot_ws/src/robot_simulation/robot_simulation/state_interface_monitor.py
@@ -6,11 +6,13 @@ from geometry_msgs.msg import WrenchStamped
 from nav_msgs.msg import Odometry
 import rclpy
 from rclpy.node import Node
+from rosgraph_msgs.msg import Clock
 from sensor_msgs.msg import Imu, JointState
 from std_msgs.msg import Bool, Float64
 
 
 FEET = ('front_left', 'front_right', 'rear_left', 'rear_right')
+MAX_HEADER_LAG_NANOSECONDS = 100_000_000
 
 
 class StateInterfaceMonitor(Node):
@@ -23,10 +25,22 @@ class StateInterfaceMonitor(Node):
         self.normal_forces = {foot: 0.0 for foot in FEET}
         self.command_joint_names = set()
         self.sensor_joint_names = set()
+        self.clock_nanoseconds = 0
+        self.clock_advanced = False
+        self.latest_header_stamps = {}
         self.base_height = 0.0
         self.logged_ready = False
         self.input_subscriptions = []
+        self.header_keys = {
+            'control_input',
+            'joint_command',
+            'imu',
+            'joint_states',
+            'ground_truth',
+        }
+        self.header_keys.update(f'wrench:{foot}' for foot in FEET)
 
+        self._subscribe(Clock, '/clock', 'clock')
         self._subscribe(JointState, '/control_inputs', 'control_input')
         self._subscribe(JointState, '/cmd_jnts', 'joint_command')
         self._subscribe(Imu, '/sim/sensors/imu', 'imu')
@@ -39,6 +53,7 @@ class StateInterfaceMonitor(Node):
             self._subscribe(WrenchStamped, f'{prefix}/wrench', f'wrench:{foot}')
 
         self.expected = {
+            'clock',
             'control_input',
             'joint_command',
             'imu',
@@ -70,6 +85,15 @@ class StateInterfaceMonitor(Node):
 
     def _mark_received(self, key, message):
         self.received.add(key)
+        if key == 'clock':
+            clock_nanoseconds = self._stamp_nanoseconds(message.clock)
+            self.clock_advanced = clock_nanoseconds > self.clock_nanoseconds
+            self.clock_nanoseconds = clock_nanoseconds
+        elif key in self.header_keys:
+            self.latest_header_stamps[key] = self._stamp_nanoseconds(
+                message.header.stamp
+            )
+
         if key == 'ground_truth':
             self.base_height = message.pose.pose.position.z
         elif key == 'joint_command':
@@ -81,6 +105,10 @@ class StateInterfaceMonitor(Node):
         elif key.startswith('normal_force:'):
             self.normal_forces[key.split(':', maxsplit=1)[1]] = message.data
 
+    @staticmethod
+    def _stamp_nanoseconds(stamp):
+        return stamp.sec * 1_000_000_000 + stamp.nanosec
+
     def publish_status(self):
         """Publish whether a coherent sample has arrived from every interface."""
         joint_names_match = (
@@ -88,10 +116,20 @@ class StateInterfaceMonitor(Node):
             and self.command_joint_names == self.sensor_joint_names
         )
         has_ground_contact = any(force > 0.0 for force in self.normal_forces.values())
+        timestamps_follow_clock = (
+            self.header_keys.issubset(self.latest_header_stamps)
+            and all(
+                0 < stamp <= self.clock_nanoseconds
+                and self.clock_nanoseconds - stamp <= MAX_HEADER_LAG_NANOSECONDS
+                for stamp in self.latest_header_stamps.values()
+            )
+        )
         ready = (
             self.expected.issubset(self.received)
             and joint_names_match
             and has_ground_contact
+            and self.clock_advanced
+            and timestamps_follow_clock
         )
         self.ready_publisher.publish(Bool(data=ready))
         if ready and not self.logged_ready:

--- a/robot_ws/src/robot_simulation/setup.py
+++ b/robot_ws/src/robot_simulation/setup.py
@@ -22,12 +22,14 @@ setup(
     zip_safe=True,
     maintainer='Mostafa Hussein',
     maintainer_email='mahussein04@gmail.com',
-    description='Headless PyBullet simulation and ROS 2 interfaces for the robot dog.',
+    description='Deterministic PyBullet simulation and idealized ROS 2 teaching sensors.',
     license='NOASSERTION',
     tests_require=['pytest'],
     entry_points={
         'console_scripts': [
             'quad_sim = robot_simulation.pybullet_sim:main',
+            'state_interface_monitor = '
+            'robot_simulation.state_interface_monitor:main',
         ],
     },
 )

--- a/robot_ws/src/robot_simulation/setup.py
+++ b/robot_ws/src/robot_simulation/setup.py
@@ -1,28 +1,29 @@
-from setuptools import find_packages, setup
 from glob import glob
+
+from setuptools import find_packages, setup
 
 package_name = 'robot_simulation'
 
 setup(
     name=package_name,
-    version='0.0.0',
+    version='0.1.0',
     packages=find_packages(exclude=['test']),
     data_files=[
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),
-        ('share/' + package_name, ['package.xml', ]),
-        ('share/' + package_name + "/launch", glob('launch/*.launch.py')),
-        ('share/' + package_name + "/rviz", glob('rviz/*.rviz')),
-        ('share/' + package_name + "/urdf", glob('urdf/*.xacro')),
-        ('share/' + package_name + "/urdf", glob('urdf/*.trans')),
-        ('share/' + package_name + "/urdf/meshes", glob('urdf/meshes/*.stl')),
+        ('share/' + package_name, ['package.xml']),
+        ('share/' + package_name + '/launch', glob('launch/*.launch.py')),
+        ('share/' + package_name + '/rviz', glob('rviz/*.rviz')),
+        ('share/' + package_name + '/urdf', glob('urdf/*.xacro')),
+        ('share/' + package_name + '/urdf', glob('urdf/*.trans')),
+        ('share/' + package_name + '/urdf/meshes', glob('urdf/meshes/*.stl')),
     ],
-    install_requires=['setuptools'],
+    install_requires=['numpy', 'pybullet', 'scipy', 'setuptools'],
     zip_safe=True,
-    maintainer='mahussein',
+    maintainer='Mostafa Hussein',
     maintainer_email='mahussein04@gmail.com',
-    description='Quadruped Simulation in Pybullet package',
-    license='TODO: License declaration',
+    description='Headless PyBullet simulation and ROS 2 interfaces for the robot dog.',
+    license='NOASSERTION',
     tests_require=['pytest'],
     entry_points={
         'console_scripts': [

--- a/robot_ws/src/robot_simulation/test/test_joint_command_mapping.py
+++ b/robot_ws/src/robot_simulation/test/test_joint_command_mapping.py
@@ -1,9 +1,15 @@
-"""Validate that semantic command groups follow complete URDF leg chains."""
+"""Validate simulation command, time, and frame invariants."""
 
 from pathlib import Path
 from xml.etree import ElementTree
 
 from robot_controller.quad_joint_controller import SIM_JOINT_NAMES_BY_LEG
+from robot_simulation.pybullet_sim import (
+    GROUND_TRUTH_BASE_FRAME,
+    GROUND_TRUTH_WORLD_FRAME,
+    JOINT_DIRECTION_BY_NAME,
+    simulation_timestamp,
+)
 
 
 ROBOT_DESCRIPTION = Path(__file__).parents[1] / 'urdf' / 'robot_core.xacro'
@@ -34,3 +40,40 @@ def test_each_command_group_is_a_base_to_foot_chain():
         foot_links.add(foot_child)
 
     assert len(foot_links) == 4
+
+
+def test_joint_directions_are_semantic_and_cover_the_urdf():
+    root = ElementTree.parse(ROBOT_DESCRIPTION).getroot()
+    urdf_joint_names = {
+        joint.attrib['name']
+        for joint in root.findall('joint')
+    }
+
+    assert set(JOINT_DIRECTION_BY_NAME) == urdf_joint_names
+    assert set(JOINT_DIRECTION_BY_NAME.values()) == {-1.0, 1.0}
+    assert {
+        name
+        for name, direction in JOINT_DIRECTION_BY_NAME.items()
+        if direction < 0.0
+    } == {
+        'Revolute_3',
+        'Revolute_5',
+        'Revolute_20',
+        'Revolute_35',
+        'Revolute_40',
+    }
+
+
+def test_simulation_timestamps_are_exact_step_multiples():
+    assert simulation_timestamp(0).sec == 0
+    assert simulation_timestamp(0).nanosec == 0
+    assert simulation_timestamp(1).nanosec == 10_000_000
+
+    timestamp = simulation_timestamp(123)
+    assert timestamp.sec == 1
+    assert timestamp.nanosec == 230_000_000
+
+
+def test_ground_truth_frames_are_distinct_from_operational_frames():
+    assert GROUND_TRUTH_WORLD_FRAME != 'world'
+    assert GROUND_TRUTH_BASE_FRAME != 'base_link'

--- a/robot_ws/src/robot_simulation/test/test_joint_command_mapping.py
+++ b/robot_ws/src/robot_simulation/test/test_joint_command_mapping.py
@@ -1,0 +1,36 @@
+"""Validate that semantic command groups follow complete URDF leg chains."""
+
+from pathlib import Path
+from xml.etree import ElementTree
+
+from robot_controller.quad_joint_controller import SIM_JOINT_NAMES_BY_LEG
+
+
+ROBOT_DESCRIPTION = Path(__file__).parents[1] / 'urdf' / 'robot_core.xacro'
+
+
+def test_each_command_group_is_a_base_to_foot_chain():
+    root = ElementTree.parse(ROBOT_DESCRIPTION).getroot()
+    joints = {
+        joint.attrib['name']: (
+            joint.find('parent').attrib['link'],
+            joint.find('child').attrib['link'],
+        )
+        for joint in root.findall('joint')
+    }
+
+    commanded_names = [name for leg in SIM_JOINT_NAMES_BY_LEG for name in leg]
+    assert len(commanded_names) == 12
+    assert len(set(commanded_names)) == 12
+
+    foot_links = set()
+    for hip_name, upper_name, foot_name in SIM_JOINT_NAMES_BY_LEG:
+        hip_parent, hip_child = joints[hip_name]
+        upper_parent, upper_child = joints[upper_name]
+        foot_parent, foot_child = joints[foot_name]
+        assert hip_parent == 'base_link'
+        assert hip_child == upper_parent
+        assert upper_child == foot_parent
+        foot_links.add(foot_child)
+
+    assert len(foot_links) == 4

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROS_DISTRO="${ROS_DISTRO:-jazzy}"
+ROS_SETUP="${ROS_SETUP:-/opt/ros/${ROS_DISTRO}/setup.bash}"
+
+if [[ ! -f "${ROS_SETUP}" ]]; then
+  echo "ROS setup file not found: ${ROS_SETUP}" >&2
+  echo "Use the devcontainer or install ROS 2 ${ROS_DISTRO} first." >&2
+  exit 1
+fi
+
+# shellcheck disable=SC1090
+set +u
+source "${ROS_SETUP}"
+set -u
+
+if ! command -v rosdep >/dev/null 2>&1; then
+  echo "rosdep is required. Install python3-rosdep and retry." >&2
+  exit 1
+fi
+
+if [[ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]]; then
+  if [[ "$(id -u)" -eq 0 ]]; then
+    rosdep init
+  elif command -v sudo >/dev/null 2>&1; then
+    sudo rosdep init
+  else
+    echo "rosdep is not initialized and sudo is unavailable." >&2
+    exit 1
+  fi
+fi
+
+rosdep update --rosdistro "${ROS_DISTRO}"
+
+if command -v apt-get >/dev/null 2>&1; then
+  if [[ "$(id -u)" -eq 0 ]]; then
+    apt-get update
+  elif command -v sudo >/dev/null 2>&1; then
+    sudo apt-get update
+  else
+    echo "APT package indexes must be updated, but sudo is unavailable." >&2
+    exit 1
+  fi
+fi
+
+rosdep install \
+  --from-paths "${PROJECT_ROOT}/robot_ws/src" \
+  --ignore-src \
+  --rosdistro "${ROS_DISTRO}" \
+  -y
+
+python3 -m venv --system-site-packages "${PROJECT_ROOT}/.venv"
+# shellcheck disable=SC1091
+source "${PROJECT_ROOT}/.venv/bin/activate"
+python -m pip install --upgrade pip==25.1.1
+python -m pip install -r "${PROJECT_ROOT}/requirements.txt"
+
+echo "Dependencies are ready. Run 'make build' next."

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/ros_env.sh"
+
+cd "${PROJECT_ROOT}/robot_ws"
+python -m colcon build --symlink-install "$@"

--- a/scripts/experiment.sh
+++ b/scripts/experiment.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/ros_env.sh"
+
+WORKSPACE_SETUP="${PROJECT_ROOT}/robot_ws/install/setup.bash"
+if [[ ! -f "${WORKSPACE_SETUP}" ]]; then
+  echo "Workspace is not built. Run 'make build' first." >&2
+  exit 1
+fi
+
+# shellcheck disable=SC1090
+set +u
+source "${WORKSPACE_SETUP}"
+set -u
+exec ros2 launch robot_simulation experiment.launch.py "$@"

--- a/scripts/ros_env.sh
+++ b/scripts/ros_env.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROS_DISTRO="${ROS_DISTRO:-jazzy}"
+ROS_SETUP="${ROS_SETUP:-/opt/ros/${ROS_DISTRO}/setup.bash}"
+
+if [[ ! -f "${ROS_SETUP}" ]]; then
+  echo "ROS setup file not found: ${ROS_SETUP}" >&2
+  echo "Install ROS 2 ${ROS_DISTRO}, use the devcontainer, or set ROS_SETUP." >&2
+  exit 1
+fi
+
+# shellcheck disable=SC1090
+set +u
+source "${ROS_SETUP}"
+
+if [[ -f "${PROJECT_ROOT}/.venv/bin/activate" ]]; then
+  # shellcheck disable=SC1091
+  source "${PROJECT_ROOT}/.venv/bin/activate"
+fi
+set -u
+
+export PROJECT_ROOT ROS_DISTRO

--- a/scripts/sim.sh
+++ b/scripts/sim.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/ros_env.sh"
+
+WORKSPACE_SETUP="${PROJECT_ROOT}/robot_ws/install/setup.bash"
+if [[ ! -f "${WORKSPACE_SETUP}" ]]; then
+  echo "Workspace is not built. Run 'make build' first." >&2
+  exit 1
+fi
+
+# shellcheck disable=SC1090
+set +u
+source "${WORKSPACE_SETUP}"
+set -u
+exec ros2 launch robot_simulation master.launch.py "$@"

--- a/scripts/smoke_sim.sh
+++ b/scripts/smoke_sim.sh
@@ -52,7 +52,8 @@ for _ in $(seq 1 20); do
 
   TOPICS="$(ros2 topic list 2>/dev/null || true)"
   NODES="$(ros2 node list 2>/dev/null || true)"
-  if grep -qx '/control_inputs' <<<"${TOPICS}" \
+  if grep -qx '/clock' <<<"${TOPICS}" \
+      && grep -qx '/control_inputs' <<<"${TOPICS}" \
       && grep -qx '/cmd_jnts' <<<"${TOPICS}" \
       && grep -qx '/joint_states' <<<"${TOPICS}" \
       && grep -qx '/tf' <<<"${TOPICS}" \
@@ -76,9 +77,39 @@ for _ in $(seq 1 20); do
       timeout 3 ros2 topic echo \
         --once /sim/experiment/ready std_msgs/msg/Bool 2>/dev/null || true
     )"
+    CONTROLLER_SIM_TIME="$(
+      ros2 param get /example_stance_controller use_sim_time 2>/dev/null || true
+    )"
+    MONITOR_SIM_TIME="$(
+      ros2 param get /state_interface_monitor use_sim_time 2>/dev/null || true
+    )"
+    SIMULATOR_SIM_TIME="$(
+      ros2 param get /quad_sim use_sim_time 2>/dev/null || true
+    )"
+    GROUND_TRUTH_TF="$(
+      ros2 param get /quad_sim publish_ground_truth_tf 2>/dev/null || true
+    )"
+    GROUND_TRUTH_SAMPLE="$(
+      timeout 3 ros2 topic echo \
+        --once /sim/ground_truth/odom nav_msgs/msg/Odometry 2>/dev/null || true
+    )"
+    TF_SAMPLE="$(
+      timeout 3 ros2 topic echo \
+        --once /tf tf2_msgs/msg/TFMessage 2>/dev/null || true
+    )"
     if grep -q 'data: true' <<<"${READY_STATUS}" \
+        && grep -q 'True' <<<"${CONTROLLER_SIM_TIME}" \
+        && grep -q 'True' <<<"${MONITOR_SIM_TIME}" \
+        && grep -q 'False' <<<"${SIMULATOR_SIM_TIME}" \
+        && grep -q 'False' <<<"${GROUND_TRUTH_TF}" \
+        && grep -q 'frame_id: sim_ground_truth_world' <<<"${GROUND_TRUTH_SAMPLE}" \
+        && grep -q 'child_frame_id: sim_ground_truth_base_link' \
+          <<<"${GROUND_TRUTH_SAMPLE}" \
+        && grep -q 'transforms:' <<<"${TF_SAMPLE}" \
+        && ! grep -q 'child_frame_id: base_link' <<<"${TF_SAMPLE}" \
+        && ! grep -q 'sim_ground_truth_' <<<"${TF_SAMPLE}" \
         && kill -0 "${LAUNCH_PID}" 2>/dev/null; then
-      echo "Simulation smoke test passed: commands, idealized sensors, contact forces, and ground truth are coherent."
+      echo "Simulation smoke test passed: step clock, clean TF, commands, sensors, contact forces, and isolated ground truth are coherent."
       exit 0
     fi
   fi

--- a/scripts/smoke_sim.sh
+++ b/scripts/smoke_sim.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/ros_env.sh"
+
+WORKSPACE_SETUP="${PROJECT_ROOT}/robot_ws/install/setup.bash"
+if [[ ! -f "${WORKSPACE_SETUP}" ]]; then
+  echo "Workspace is not built. Run 'make build' first." >&2
+  exit 1
+fi
+
+# shellcheck disable=SC1090
+set +u
+source "${WORKSPACE_SETUP}"
+set -u
+
+SMOKE_LOG="$(mktemp -t robot-dog-smoke.XXXXXX.log)"
+LAUNCH_PID=""
+
+cleanup() {
+  if [[ -n "${LAUNCH_PID}" ]] && kill -0 "${LAUNCH_PID}" 2>/dev/null; then
+    kill -INT "${LAUNCH_PID}" 2>/dev/null || true
+    for _ in $(seq 1 10); do
+      if ! kill -0 "${LAUNCH_PID}" 2>/dev/null; then
+        break
+      fi
+      sleep 0.5
+    done
+    if kill -0 "${LAUNCH_PID}" 2>/dev/null; then
+      kill -TERM "${LAUNCH_PID}" 2>/dev/null || true
+    fi
+    wait "${LAUNCH_PID}" 2>/dev/null || true
+  fi
+  rm -f "${SMOKE_LOG}"
+}
+trap cleanup EXIT
+
+ros2 launch robot_simulation master.launch.py \
+  use_foxglove:=true \
+  use_rviz:=false >"${SMOKE_LOG}" 2>&1 &
+LAUNCH_PID=$!
+
+for _ in $(seq 1 20); do
+  if ! kill -0 "${LAUNCH_PID}" 2>/dev/null; then
+    echo "Simulation launch exited before becoming ready." >&2
+    cat "${SMOKE_LOG}" >&2
+    exit 1
+  fi
+
+  TOPICS="$(ros2 topic list 2>/dev/null || true)"
+  NODES="$(ros2 node list 2>/dev/null || true)"
+  if grep -qx '/joint_states' <<<"${TOPICS}" \
+      && grep -qx '/tf' <<<"${TOPICS}" \
+      && grep -qx '/foxglove_bridge' <<<"${NODES}" \
+      && grep -qx '/quad_controller' <<<"${NODES}" \
+      && grep -qx '/quad_sim' <<<"${NODES}" \
+      && grep -qx '/robot_state_publisher' <<<"${NODES}"; then
+    sleep 1
+    if kill -0 "${LAUNCH_PID}" 2>/dev/null; then
+      echo "Simulation smoke test passed: core nodes, Foxglove, /joint_states, and /tf are available."
+      exit 0
+    fi
+  fi
+  sleep 1
+done
+
+echo "Simulation nodes and topics did not become ready within 20 seconds." >&2
+cat "${SMOKE_LOG}" >&2
+exit 1

--- a/scripts/smoke_sim.sh
+++ b/scripts/smoke_sim.sh
@@ -38,7 +38,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-ros2 launch robot_simulation master.launch.py \
+ros2 launch robot_simulation experiment.launch.py \
   use_foxglove:=true \
   use_rviz:=false >"${SMOKE_LOG}" 2>&1 &
 LAUNCH_PID=$!
@@ -52,21 +52,39 @@ for _ in $(seq 1 20); do
 
   TOPICS="$(ros2 topic list 2>/dev/null || true)"
   NODES="$(ros2 node list 2>/dev/null || true)"
-  if grep -qx '/joint_states' <<<"${TOPICS}" \
+  if grep -qx '/control_inputs' <<<"${TOPICS}" \
+      && grep -qx '/cmd_jnts' <<<"${TOPICS}" \
+      && grep -qx '/joint_states' <<<"${TOPICS}" \
       && grep -qx '/tf' <<<"${TOPICS}" \
+      && grep -qx '/sim/experiment/ready' <<<"${TOPICS}" \
+      && grep -qx '/sim/ground_truth/odom' <<<"${TOPICS}" \
+      && grep -qx '/sim/sensors/imu' <<<"${TOPICS}" \
+      && grep -qx '/sim/sensors/joint_states' <<<"${TOPICS}" \
+      && grep -qx '/sim/sensors/foot_contacts/front_left' <<<"${TOPICS}" \
+      && grep -qx '/sim/sensors/foot_contacts/front_left/normal_force' <<<"${TOPICS}" \
+      && grep -qx '/sim/sensors/foot_contacts/front_left/wrench' <<<"${TOPICS}" \
+      && grep -qx '/sim/sensors/foot_contacts/front_right' <<<"${TOPICS}" \
+      && grep -qx '/sim/sensors/foot_contacts/rear_left' <<<"${TOPICS}" \
+      && grep -qx '/sim/sensors/foot_contacts/rear_right' <<<"${TOPICS}" \
       && grep -qx '/foxglove_bridge' <<<"${NODES}" \
+      && grep -qx '/example_stance_controller' <<<"${NODES}" \
       && grep -qx '/quad_controller' <<<"${NODES}" \
       && grep -qx '/quad_sim' <<<"${NODES}" \
-      && grep -qx '/robot_state_publisher' <<<"${NODES}"; then
-    sleep 1
-    if kill -0 "${LAUNCH_PID}" 2>/dev/null; then
-      echo "Simulation smoke test passed: core nodes, Foxglove, /joint_states, and /tf are available."
+      && grep -qx '/robot_state_publisher' <<<"${NODES}" \
+      && grep -qx '/state_interface_monitor' <<<"${NODES}"; then
+    READY_STATUS="$(
+      timeout 3 ros2 topic echo \
+        --once /sim/experiment/ready std_msgs/msg/Bool 2>/dev/null || true
+    )"
+    if grep -q 'data: true' <<<"${READY_STATUS}" \
+        && kill -0 "${LAUNCH_PID}" 2>/dev/null; then
+      echo "Simulation smoke test passed: commands, idealized sensors, contact forces, and ground truth are coherent."
       exit 0
     fi
   fi
   sleep 1
 done
 
-echo "Simulation nodes and topics did not become ready within 20 seconds." >&2
+echo "Experiment nodes and topics did not become ready within 20 seconds." >&2
 cat "${SMOKE_LOG}" >&2
 exit 1

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/ros_env.sh"
+
+cd "${PROJECT_ROOT}/robot_ws"
+python -m colcon test --event-handlers console_direct+ "$@"
+python -m colcon test-result --verbose


### PR DESCRIPTION
## Summary

- replace the personal floating development image with a pinned official ROS 2 Jazzy/Ubuntu 24.04 devcontainer
- pin Python runtime dependencies, declare ROS dependencies, and add consistent setup/build/test/run workflows
- add pinned GitHub Actions build, test, and headless simulation-smoke CI
- keep remote visualization headless by default through Foxglove on port 8765, with RViz opt-in
- add `make experiment`: a deterministic gentle stance example using the existing controller adapter and simplified PyBullet model
- address commands through an explicit semantic URDF joint-name/direction map, with regression coverage independent of URDF joint ordering
- publish idealized/mock teaching interfaces for IMU-like data, joint encoders, per-foot contact flags, normal force, contact wrench, and separately namespaced ground truth
- advance `/clock` in exact 10 ms physics-step increments and use simulated time for command, sensor, and visualization headers
- keep exact ground truth out of the operational global TF tree by default; the optional visualization TF uses only `sim_ground_truth_world -> sim_ground_truth_base_link`
- add an example subscriber/readiness monitor and a live smoke test proving commands, measured joint names, clocked sensor streams, clean operational TF, and a nonzero contact event work together
- document topic/frame semantics, simulation limitations, remote visualization, URDF history, and a first contact-aided vertical-velocity exercise

## Scope and honesty

This is a reproducible PyBullet teaching baseline, not a validated physical model or real state estimator. Sensor data are noise-free/mock simulation outputs. Ground truth is deliberately separate from estimator inputs and operational frames. MuJoCo, closed-loop model recovery, hardware sensor models, navigation, and learning environments remain future work.

No repository-level license has been selected; package metadata records this as `NOASSERTION`.

## Validation

- rebuilt the pinned devcontainer image successfully
- `make setup`: all rosdep and pinned Python dependencies resolved
- `make build`: all 3 ROS packages built
- `make test`: 14 tests, 0 errors, 0 failures; 3 existing license checks skipped
- `make smoke`: verified the exact step clock, simulated-time consumers, clean operational TF, example controller, semantic command mapping, IMU, joint state, four foot-contact flag/normal-force/wrench streams, isolated ground truth, Foxglove, and a real nonzero PyBullet foot contact
- repeated build/test/smoke with the repository-local virtualenv hidden to verify the fresh devcontainer is self-contained
- live-checked the opt-in truth TF path and confirmed it publishes only the isolated `sim_ground_truth_world -> sim_ground_truth_base_link` transform
