### PR TITLE
Add deterministic MuJoCo simulator core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: ROS 2 baseline
+name: Reproducible simulators
 
 on:
   pull_request:
@@ -41,7 +41,10 @@ jobs:
       - name: Run tests
         run: make test
 
-      - name: Smoke-test headless simulation
+      - name: Smoke-test deterministic MuJoCo core
+        run: make mujoco-smoke
+
+      - name: Smoke-test headless PyBullet teaching stack
         run: make smoke
 
       - name: Upload ROS logs on failure

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ export ROS_DISTRO
 
 .DEFAULT_GOAL := help
 
-.PHONY: help setup build test sim experiment smoke
+.PHONY: help setup build test sim experiment smoke mujoco-smoke
 
 help:
 	@echo "Robot Dog developer commands"
@@ -15,6 +15,7 @@ help:
 	@echo "  make sim     Start the PyBullet simulation and Foxglove bridge"
 	@echo "  make experiment  Run the example controller and sensor teaching slice"
 	@echo "  make smoke   Verify commands and simulated sensor topics end to end"
+	@echo "  make mujoco-smoke  Verify the deterministic headless MuJoCo core"
 	@echo
 	@echo "Override ROS_DISTRO when needed, for example: ROS_DISTRO=humble make build"
 
@@ -35,3 +36,6 @@ experiment:
 
 smoke:
 	./scripts/smoke_sim.sh
+
+mujoco-smoke:
+	./scripts/smoke_mujoco.sh

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Robot Dog
 
-Robot Dog is a ROS 2 learning project built around a custom quadruped. The repository currently contains a simplified robot description, a headless PyBullet proof-of-concept, and a basic inverse-kinematics command adapter. It is being revived as an environment for learning robot control, navigation, state estimation, and robot learning.
+Robot Dog is a ROS 2 learning project built around a custom quadruped. The repository currently contains a simplified robot description, a headless PyBullet teaching stack, a ROS-independent MuJoCo simulator core, and a basic inverse-kinematics command adapter. It is being revived as an environment for learning robot control, navigation, state estimation, and robot learning.
 
 This baseline targets **ROS 2 Jazzy on Ubuntu 24.04**. The previous project used ROS 2 Humble; Humble may still work, but it is not the reproducible target used by CI.
 
@@ -10,15 +10,15 @@ This baseline targets **ROS 2 Jazzy on Ubuntu 24.04**. The previous project used
 | --- | --- |
 | Development environment | Reproducible ROS 2 Jazzy devcontainer and pinned Python dependencies |
 | Robot description | Simplified open-chain Xacro/URDF with 12 actuated joints |
-| Simulation | Headless, fixed-step PyBullet node with idealized teaching sensors and separate ground truth |
+| Simulation | Headless PyBullet teaching node plus a deterministic, ROS-independent MuJoCo reset/step core |
 | Control | Per-leg IK plus a deterministic, gentle stance-height example controller |
 | Visualization | Robot state publisher, optional RViz, and a Foxglove bridge on port `8765` |
 | Tests | ROS package tests plus an end-to-end command/sensor headless smoke test |
-| MuJoCo | Not implemented yet; planned as the next simulator vertical slice |
+| MuJoCo | Minimal 12-joint primitive model, fixed-step reset/step, idealized teaching data, separate ground truth, and headless determinism smoke test |
 | State estimation, navigation, learning | No estimator or environment yet; a PyBullet teaching interface is available |
 | Hardware and firmware | Not present in this repository |
 
-The existing simulation is a development checkpoint, not a validated model of the physical robot. Its sensors are noise-free/mock PyBullet outputs, and it has no hardware sensor model, environment API, controller benchmarks, or dynamics validation yet.
+Both simulators are development checkpoints, not validated models of the physical robot. Their sensors are noise-free/mock outputs, and there is no hardware sensor model, state estimator, learning environment, controller benchmark, or dynamics validation yet.
 
 ## Quick start
 
@@ -31,6 +31,7 @@ The supported path is the included devcontainer. It pins the ROS base image and 
    ```bash
    make build
    make test
+   make mujoco-smoke
    make smoke
    ```
 
@@ -84,11 +85,42 @@ make sim SIM_ARGS="use_rviz:=true use_foxglove:=false"
 | `make setup` | Resolve ROS dependencies and install pinned Python dependencies |
 | `make build` | Build `robot_ws` using a symlink install |
 | `make test` | Run all package tests and print the complete result summary |
+| `make mujoco-smoke` | Run two identical headless MuJoCo trajectories and require exact equality, finite sensors, and foot contact |
 | `make smoke` | Verify simulation time, clean TF, commands, sensors, forces, and truth |
 | `make sim` | Launch PyBullet, the joint controller, robot state publisher, and Foxglove |
 | `make experiment` | Add the deterministic example controller and interface monitor |
 
-All commands accept a different installed ROS distribution through `ROS_DISTRO`, for example `ROS_DISTRO=humble make build`. Jazzy remains the tested target.
+ROS commands accept a different installed distribution through `ROS_DISTRO`, for example `ROS_DISTRO=humble make build`. Jazzy remains the tested target. `make mujoco-smoke` is deliberately ROS-independent.
+
+## Phase 2 MuJoCo core
+
+The MuJoCo path is a small simulator core, not a ROS node or learning algorithm. It loads one documented primitive-only MJCF model and exposes ordinary Python `reset()`, `step(command)`, and `observe()` methods. Each `step` advances exactly one fixed 2 ms physics tick. Each `reset` restores the same keyframe, holds the safe stance through a fixed number of settling steps, resets episode time to zero, and returns copied data.
+
+```python
+from robot_simulation.mujoco_core import MujocoSimulator
+
+simulator = MujocoSimulator()
+initial = simulator.reset()
+result = simulator.step({'Revolute_25': 0.47})
+
+mock_imu = result.sensors.imu
+evaluation_pose = result.ground_truth.position_world
+```
+
+Commands use the same 12 explicit simplified-model joint names as `/cmd_jnts`. A partial command updates named targets and omitted joints hold their previous targets. Unknown, duplicate, non-finite, and out-of-range targets are rejected instead of silently changing command meaning. `MujocoSimulator.safe_stance_command()` returns the full conservative target set.
+
+The returned interface deliberately separates data by intended use:
+
+| Field | Semantics |
+| --- | --- |
+| `result.sensors.imu` | Ideal orientation, body-frame angular velocity, and body-frame specific force; no noise, bias, saturation, or estimator claim |
+| `result.sensors.joint_states` | Ideal named position, velocity, and actuator effort in canonical command order |
+| `result.sensors.foot_contacts[foot]` | Per-foot contact flag, summed normal force, and simulated force/torque about the foot site in the foot frame |
+| `result.ground_truth` | Exact base pose and body-frame velocity, isolated in a separate object for evaluation |
+
+The [minimal model](robot_ws/src/robot_simulation/robot_simulation/models/README.md) uses a box torso, capsule legs, spherical feet, approximate masses, and no CAD assets. It omits the real closed-chain leg geometry and actuator/sensor imperfections. MuJoCo itself is pinned, and the model fixes its timestep, integrator, solver, iteration count, tolerance, friction cone, and reset state. The smoke test checks exact repeatability within the supported environment; it does not promise bitwise identity across different MuJoCo versions, CPU architectures, or compiler builds.
+
+ROS and Gymnasium adapters are intentionally deferred. An eventual adapter should translate this core's existing command/result objects at the boundary rather than add ROS timing or learning-framework state to the core.
 
 ## PyBullet teaching experiment
 
@@ -145,7 +177,7 @@ This exercise teaches frame transforms, IMU conventions, contact gating, and eva
 ├── robot_ws/src/
 │   ├── robot_controller # Leg kinematics and ROS command adapter
 │   ├── robot_desc       # Simplified Xacro/URDF and visualization launch
-│   └── robot_simulation # Headless PyBullet simulator and top-level launch
+│   └── robot_simulation # PyBullet ROS stack plus deterministic MuJoCo core/model
 ├── scripts/             # Reusable setup/build/test/run entry points
 ├── Makefile
 └── requirements.txt
@@ -160,7 +192,7 @@ An older, more detailed open-chain export of the mechanism exists in Git history
 ## Revival roadmap
 
 1. **Reproducible baseline** — repeatable environment, declared dependencies, CI, and a verified PyBullet launch. This repository state covers that phase.
-2. **MuJoCo vertical slice** — load one canonical model, step deterministically, apply joint commands, publish state, and render offscreen.
+2. **MuJoCo vertical slice** — the ROS-independent core now loads one canonical simplified model, resets/steps deterministically, applies named joint commands, and exposes idealized sensor data with separate ground truth. Rendering and adapters remain deferred.
 3. **Model fidelity** — recover the detailed mechanism, add loop-closure constraints, simplify collision geometry, and validate mass/inertia/joint conventions.
 4. **Robotics interfaces** — the idealized sensor teaching slice has started this phase; state estimators, navigation interfaces, and controller benchmarks remain.
 5. **Learning environment** — Gymnasium-style reset/step API, observations/actions/rewards, reproducible experiments, and ROS adapters at the boundary.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 # Python runtime dependencies. ROS dependencies are installed through rosdep.
 numpy==1.26.4
+mujoco==3.6.0
 pybullet==3.2.7
 scipy==1.15.3

--- a/robot_ws/src/robot_simulation/package.xml
+++ b/robot_ws/src/robot_simulation/package.xml
@@ -2,8 +2,8 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>robot_simulation</name>
-  <version>0.1.0</version>
-  <description>Deterministic PyBullet simulation and idealized ROS 2 teaching sensors.</description>
+  <version>0.2.0</version>
+  <description>Deterministic teaching simulators with explicit sensor/truth boundaries.</description>
   <maintainer email="mahussein04@gmail.com">Mostafa Hussein</maintainer>
   <license>NOASSERTION</license>
 

--- a/robot_ws/src/robot_simulation/robot_simulation/models/README.md
+++ b/robot_ws/src/robot_simulation/robot_simulation/models/README.md
@@ -1,0 +1,16 @@
+# Minimal MuJoCo teaching model
+
+`minimal_quadruped.xml` is the Phase 2 simulator model. It is deliberately a
+small deterministic test fixture, not a digital twin:
+
+- one 6 kg box torso, primitive capsule legs, and spherical feet;
+- three hinge joints per leg using the baseline `/cmd_jnts` names and leg order;
+- position actuators with bounded force and target ranges;
+- a 2 ms fixed timestep, explicit Newton solver settings, and one plane;
+- an IMU site plus named foot geoms/sites used by the Python sensor interface;
+- a conservative `safe_stance` keyframe used by every reset.
+
+Masses and dimensions are approximate. The model omits the physical closed-chain
+mechanism, CAD meshes, actuator dynamics, backlash, compliance, sensor
+noise/bias/saturation, cabling, and hardware validation. Those belong to later
+model-fidelity work and should not be inferred from this file.

--- a/robot_ws/src/robot_simulation/robot_simulation/models/minimal_quadruped.xml
+++ b/robot_ws/src/robot_simulation/robot_simulation/models/minimal_quadruped.xml
@@ -1,0 +1,173 @@
+<mujoco model="robot_dog_minimal">
+  <!--
+    Phase 2 teaching model: intentionally simple primitives, approximate inertias,
+    no closed-chain mechanism, no CAD meshes, and no hardware-fidelity claim.
+    Coordinates are x-forward, y-left, z-up. Joint names match /cmd_jnts.
+  -->
+  <compiler angle="radian" autolimits="true" inertiafromgeom="true"/>
+  <option timestep="0.002" gravity="0 0 -9.81" integrator="implicitfast"
+          solver="Newton" iterations="20" tolerance="1e-10" cone="elliptic"/>
+
+  <default>
+    <joint damping="0.8" armature="0.01"/>
+    <geom condim="3" friction="0.9 0.02 0.001" solref="0.012 1"
+          solimp="0.9 0.95 0.001" density="500" rgba="0.45 0.55 0.65 1"/>
+    <position kp="55" kv="4" ctrllimited="true" forcelimited="true"
+              forcerange="-35 35"/>
+  </default>
+
+  <asset>
+    <material name="ground" rgba="0.24 0.27 0.30 1"/>
+    <material name="body" rgba="0.18 0.40 0.68 1"/>
+    <material name="right_leg" rgba="0.78 0.45 0.16 1"/>
+    <material name="left_leg" rgba="0.20 0.62 0.42 1"/>
+    <material name="foot" rgba="0.12 0.12 0.12 1"/>
+  </asset>
+
+  <worldbody>
+    <light pos="0 0 2" dir="0 0 -1" diffuse="0.8 0.8 0.8"/>
+    <geom name="ground" type="plane" size="2 2 0.1" material="ground"
+          density="0" friction="0.9 0.02 0.001"/>
+
+    <body name="base" pos="0 0 0.225">
+      <freejoint name="base_free"/>
+      <geom name="base_geom" type="box" size="0.18 0.075 0.035"
+            mass="6.0" material="body"/>
+      <site name="imu" pos="0 0 0" size="0.008" rgba="1 0 0 1"/>
+
+      <body name="front_right_hip" pos="0.145 -0.085 0">
+        <joint name="Revolute_1" type="hinge" axis="1 0 0" range="-0.6 0.6"/>
+        <geom name="front_right_hip_geom" type="capsule"
+              fromto="0 0 0 0 -0.035 0" size="0.018" mass="0.20"
+              material="right_leg"/>
+        <body name="front_right_thigh" pos="0 -0.035 0">
+          <joint name="Revolute_25" type="hinge" axis="0 1 0"
+                 range="-1.2 1.2"/>
+          <geom name="front_right_thigh_geom" type="capsule"
+                fromto="0 0 0 0 0 -0.10" size="0.015" mass="0.25"
+                material="right_leg"/>
+          <body name="front_right_calf" pos="0 0 -0.10">
+            <joint name="Revolute_40" type="hinge" axis="0 1 0"
+                   range="-2.0 0.3"/>
+            <geom name="front_right_calf_geom" type="capsule"
+                  fromto="0 0 0 0 0 -0.105" size="0.013" mass="0.20"
+                  material="right_leg"/>
+            <body name="front_right_foot" pos="0 0 -0.105">
+              <geom name="front_right_foot_geom" type="sphere" size="0.022"
+                    mass="0.08" material="foot"/>
+              <site name="front_right_foot_site" size="0.024" rgba="0 0 0 0"/>
+            </body>
+          </body>
+        </body>
+      </body>
+
+      <body name="rear_right_hip" pos="-0.145 -0.085 0">
+        <joint name="Revolute_3" type="hinge" axis="1 0 0" range="-0.6 0.6"/>
+        <geom name="rear_right_hip_geom" type="capsule"
+              fromto="0 0 0 0 -0.035 0" size="0.018" mass="0.20"
+              material="right_leg"/>
+        <body name="rear_right_thigh" pos="0 -0.035 0">
+          <joint name="Revolute_20" type="hinge" axis="0 1 0"
+                 range="-1.2 1.2"/>
+          <geom name="rear_right_thigh_geom" type="capsule"
+                fromto="0 0 0 0 0 -0.10" size="0.015" mass="0.25"
+                material="right_leg"/>
+          <body name="rear_right_calf" pos="0 0 -0.10">
+            <joint name="Revolute_23" type="hinge" axis="0 1 0"
+                   range="-2.0 0.3"/>
+            <geom name="rear_right_calf_geom" type="capsule"
+                  fromto="0 0 0 0 0 -0.105" size="0.013" mass="0.20"
+                  material="right_leg"/>
+            <body name="rear_right_foot" pos="0 0 -0.105">
+              <geom name="rear_right_foot_geom" type="sphere" size="0.022"
+                    mass="0.08" material="foot"/>
+              <site name="rear_right_foot_site" size="0.024" rgba="0 0 0 0"/>
+            </body>
+          </body>
+        </body>
+      </body>
+
+      <body name="rear_left_hip" pos="-0.145 0.085 0">
+        <joint name="Revolute_4" type="hinge" axis="1 0 0" range="-0.6 0.6"/>
+        <geom name="rear_left_hip_geom" type="capsule"
+              fromto="0 0 0 0 0.035 0" size="0.018" mass="0.20"
+              material="left_leg"/>
+        <body name="rear_left_thigh" pos="0 0.035 0">
+          <joint name="Revolute_35" type="hinge" axis="0 1 0"
+                 range="-1.2 1.2"/>
+          <geom name="rear_left_thigh_geom" type="capsule"
+                fromto="0 0 0 0 0 -0.10" size="0.015" mass="0.25"
+                material="left_leg"/>
+          <body name="rear_left_calf" pos="0 0 -0.10">
+            <joint name="Revolute_45" type="hinge" axis="0 1 0"
+                   range="-2.0 0.3"/>
+            <geom name="rear_left_calf_geom" type="capsule"
+                  fromto="0 0 0 0 0 -0.105" size="0.013" mass="0.20"
+                  material="left_leg"/>
+            <body name="rear_left_foot" pos="0 0 -0.105">
+              <geom name="rear_left_foot_geom" type="sphere" size="0.022"
+                    mass="0.08" material="foot"/>
+              <site name="rear_left_foot_site" size="0.024" rgba="0 0 0 0"/>
+            </body>
+          </body>
+        </body>
+      </body>
+
+      <body name="front_left_hip" pos="0.145 0.085 0">
+        <joint name="Revolute_5" type="hinge" axis="1 0 0" range="-0.6 0.6"/>
+        <geom name="front_left_hip_geom" type="capsule"
+              fromto="0 0 0 0 0.035 0" size="0.018" mass="0.20"
+              material="left_leg"/>
+        <body name="front_left_thigh" pos="0 0.035 0">
+          <joint name="Revolute_31" type="hinge" axis="0 1 0"
+                 range="-1.2 1.2"/>
+          <geom name="front_left_thigh_geom" type="capsule"
+                fromto="0 0 0 0 0 -0.10" size="0.015" mass="0.25"
+                material="left_leg"/>
+          <body name="front_left_calf" pos="0 0 -0.10">
+            <joint name="Revolute_48" type="hinge" axis="0 1 0"
+                   range="-2.0 0.3"/>
+            <geom name="front_left_calf_geom" type="capsule"
+                  fromto="0 0 0 0 0 -0.105" size="0.013" mass="0.20"
+                  material="left_leg"/>
+            <body name="front_left_foot" pos="0 0 -0.105">
+              <geom name="front_left_foot_geom" type="sphere" size="0.022"
+                    mass="0.08" material="foot"/>
+              <site name="front_left_foot_site" size="0.024" rgba="0 0 0 0"/>
+            </body>
+          </body>
+        </body>
+      </body>
+    </body>
+  </worldbody>
+
+  <actuator>
+    <position name="act_Revolute_1" joint="Revolute_1" ctrlrange="-0.6 0.6"/>
+    <position name="act_Revolute_25" joint="Revolute_25" ctrlrange="-1.2 1.2"/>
+    <position name="act_Revolute_40" joint="Revolute_40" ctrlrange="-2.0 0.3"/>
+    <position name="act_Revolute_3" joint="Revolute_3" ctrlrange="-0.6 0.6"/>
+    <position name="act_Revolute_20" joint="Revolute_20" ctrlrange="-1.2 1.2"/>
+    <position name="act_Revolute_23" joint="Revolute_23" ctrlrange="-2.0 0.3"/>
+    <position name="act_Revolute_4" joint="Revolute_4" ctrlrange="-0.6 0.6"/>
+    <position name="act_Revolute_35" joint="Revolute_35" ctrlrange="-1.2 1.2"/>
+    <position name="act_Revolute_45" joint="Revolute_45" ctrlrange="-2.0 0.3"/>
+    <position name="act_Revolute_5" joint="Revolute_5" ctrlrange="-0.6 0.6"/>
+    <position name="act_Revolute_31" joint="Revolute_31" ctrlrange="-1.2 1.2"/>
+    <position name="act_Revolute_48" joint="Revolute_48" ctrlrange="-2.0 0.3"/>
+  </actuator>
+
+  <sensor>
+    <gyro name="imu_gyro" site="imu"/>
+    <accelerometer name="imu_specific_force" site="imu"/>
+  </sensor>
+
+  <keyframe>
+    <!-- free joint: xyz + wxyz, followed by joints in model declaration order -->
+    <key name="safe_stance"
+         qpos="0 0 0.225 1 0 0 0
+               0 0.45 -0.90  0 0.45 -0.90
+               0 0.45 -0.90  0 0.45 -0.90"
+         ctrl="0 0.45 -0.90  0 0.45 -0.90
+               0 0.45 -0.90  0 0.45 -0.90"/>
+  </keyframe>
+</mujoco>

--- a/robot_ws/src/robot_simulation/robot_simulation/mujoco_core.py
+++ b/robot_ws/src/robot_simulation/robot_simulation/mujoco_core.py
@@ -201,7 +201,7 @@ class MujocoSimulator:
         ).reshape(3, 3)
         base_velocity = np.asarray(self.data.qvel[:6])
         linear_velocity_body = rotation_world_from_body.T @ base_velocity[:3]
-        angular_velocity_body = rotation_world_from_body.T @ base_velocity[3:]
+        angular_velocity_body = base_velocity[3:]
 
         joint_positions = []
         joint_velocities = []
@@ -263,6 +263,8 @@ class MujocoSimulator:
         unknown = set(target_by_name) - set(JOINT_NAMES)
         if unknown:
             raise ValueError(f'unknown joint command names: {sorted(unknown)}')
+
+        validated_targets = []
         for name, value in target_by_name.items():
             actuator_id = self._actuator_ids[name]
             low, high = self.model.actuator_ctrlrange[actuator_id]
@@ -270,7 +272,10 @@ class MujocoSimulator:
                 raise ValueError(
                     f'joint target {name}={value} outside [{low}, {high}]'
                 )
-            self._targets[JOINT_NAMES.index(name)] = value
+            validated_targets.append((JOINT_NAMES.index(name), value))
+
+        for target_index, value in validated_targets:
+            self._targets[target_index] = value
 
     def _write_controls(self):
         for target, name in zip(self._targets, JOINT_NAMES):

--- a/robot_ws/src/robot_simulation/robot_simulation/mujoco_core.py
+++ b/robot_ws/src/robot_simulation/robot_simulation/mujoco_core.py
@@ -1,0 +1,354 @@
+"""Provide a deterministic, ROS-independent MuJoCo teaching core."""
+
+from dataclasses import dataclass
+from pathlib import Path
+from types import MappingProxyType
+from typing import Mapping, Sequence
+
+import mujoco
+import numpy as np
+
+
+JOINT_NAMES_BY_LEG = (
+    ('Revolute_1', 'Revolute_25', 'Revolute_40'),
+    ('Revolute_3', 'Revolute_20', 'Revolute_23'),
+    ('Revolute_4', 'Revolute_35', 'Revolute_45'),
+    ('Revolute_5', 'Revolute_31', 'Revolute_48'),
+)
+JOINT_NAMES = tuple(name for leg in JOINT_NAMES_BY_LEG for name in leg)
+FOOT_NAMES = ('front_left', 'front_right', 'rear_left', 'rear_right')
+SAFE_STANCE_POSITIONS = (0.0, 0.45, -0.90) * 4
+DEFAULT_MODEL_PATH = (
+    Path(__file__).with_name('models') / 'minimal_quadruped.xml'
+)
+
+
+def _readonly(values):
+    """Copy numeric values into a read-only float array."""
+    result = np.asarray(values, dtype=np.float64).copy()
+    result.setflags(write=False)
+    return result
+
+
+@dataclass(frozen=True)
+class JointCommand:
+    """Named position targets; omitted joints hold their last target."""
+
+    names: tuple[str, ...]
+    positions: tuple[float, ...]
+
+    def __post_init__(self):
+        """Reject ambiguous or numerically invalid commands."""
+        if len(self.names) != len(self.positions):
+            raise ValueError(
+                'joint command names and positions must have equal lengths'
+            )
+        if len(set(self.names)) != len(self.names):
+            raise ValueError('joint command names must be unique')
+        if not np.all(np.isfinite(self.positions)):
+            raise ValueError('joint command positions must be finite')
+
+    @classmethod
+    def from_mapping(cls, positions: Mapping[str, float]):
+        """Construct a command while retaining the mapping iteration order."""
+        return cls(
+            tuple(positions),
+            tuple(float(value) for value in positions.values()),
+        )
+
+
+@dataclass(frozen=True)
+class ImuSample:
+    """Noise-free mock IMU data in the base frame."""
+
+    orientation_wxyz: np.ndarray
+    angular_velocity_body: np.ndarray
+    specific_force_body: np.ndarray
+
+
+@dataclass(frozen=True)
+class JointStateSample:
+    """Noise-free simulated joint state in canonical command order."""
+
+    names: tuple[str, ...]
+    positions: np.ndarray
+    velocities: np.ndarray
+    efforts: np.ndarray
+
+
+@dataclass(frozen=True)
+class FootContactSample:
+    """Idealized contact and simulated wrench about a foot site."""
+
+    in_contact: bool
+    normal_force: float
+    force_foot: np.ndarray
+    torque_foot: np.ndarray
+
+
+@dataclass(frozen=True)
+class SensorData:
+    """Experiment inputs that do not include simulator ground truth."""
+
+    imu: ImuSample
+    joint_states: JointStateSample
+    foot_contacts: Mapping[str, FootContactSample]
+
+
+@dataclass(frozen=True)
+class GroundTruth:
+    """Exact simulator base state for evaluation, never an estimator input."""
+
+    position_world: np.ndarray
+    orientation_wxyz: np.ndarray
+    linear_velocity_body: np.ndarray
+    angular_velocity_body: np.ndarray
+
+
+@dataclass(frozen=True)
+class StepResult:
+    """One timestamped result with sensors and evaluation truth separated."""
+
+    time: float
+    sensors: SensorData
+    ground_truth: GroundTruth
+
+
+class MujocoSimulator:
+    """Own one deterministic MuJoCo model/data pair with fixed-step control."""
+
+    def __init__(self, model_path=None, settle_steps=250):
+        """Load and validate one model, then enter its safe stance."""
+        if settle_steps < 0:
+            raise ValueError('settle_steps must be non-negative')
+        path = (
+            Path(model_path)
+            if model_path is not None
+            else DEFAULT_MODEL_PATH
+        )
+        self.model = mujoco.MjModel.from_xml_path(str(path))
+        self.data = mujoco.MjData(self.model)
+        self.settle_steps = settle_steps
+        self._validate_model()
+        self._joint_ids = {
+            name: self.model.joint(name).id for name in JOINT_NAMES
+        }
+        self._actuator_ids = {
+            name: self.model.actuator(f'act_{name}').id for name in JOINT_NAMES
+        }
+        self._foot_geom_ids = {
+            foot: self.model.geom(f'{foot}_foot_geom').id
+            for foot in FOOT_NAMES
+        }
+        self._foot_site_ids = {
+            foot: self.model.site(f'{foot}_foot_site').id
+            for foot in FOOT_NAMES
+        }
+        self._ground_geom_id = self.model.geom('ground').id
+        self._base_body_id = self.model.body('base').id
+        self._targets = np.asarray(SAFE_STANCE_POSITIONS, dtype=np.float64)
+        self.reset()
+
+    @property
+    def timestep(self):
+        """Return the immutable physics step size in seconds."""
+        return float(self.model.opt.timestep)
+
+    @property
+    def joint_targets(self):
+        """Return a read-only copy of the persistent named position targets."""
+        return MappingProxyType({
+            name: float(target)
+            for name, target in zip(JOINT_NAMES, self._targets)
+        })
+
+    @staticmethod
+    def safe_stance_command():
+        """Return the conservative full-joint command used during reset."""
+        return JointCommand(JOINT_NAMES, SAFE_STANCE_POSITIONS)
+
+    def reset(self):
+        """Return the same settled safe stance on every call."""
+        mujoco.mj_resetDataKeyframe(self.model, self.data, 0)
+        self._targets = np.asarray(SAFE_STANCE_POSITIONS, dtype=np.float64)
+        self._write_controls()
+        mujoco.mj_forward(self.model, self.data)
+        for _ in range(self.settle_steps):
+            mujoco.mj_step(self.model, self.data)
+        self.data.time = 0.0
+        mujoco.mj_forward(self.model, self.data)
+        return self.observe()
+
+    def step(self, command=None):
+        """Apply an optional command and advance exactly one model tick."""
+        if command is not None:
+            if isinstance(command, Mapping):
+                command = JointCommand.from_mapping(command)
+            if not isinstance(command, JointCommand):
+                raise TypeError(
+                    'command must be JointCommand, a mapping, or None'
+                )
+            self._apply_command(command)
+        self._write_controls()
+        mujoco.mj_step(self.model, self.data)
+        return self.observe()
+
+    def observe(self):
+        """Copy the current state into explicit sensor and truth containers."""
+        orientation = _readonly(self.data.xquat[self._base_body_id])
+        rotation_world_from_body = np.asarray(
+            self.data.xmat[self._base_body_id]
+        ).reshape(3, 3)
+        base_velocity = np.asarray(self.data.qvel[:6])
+        linear_velocity_body = rotation_world_from_body.T @ base_velocity[:3]
+        angular_velocity_body = rotation_world_from_body.T @ base_velocity[3:]
+
+        joint_positions = []
+        joint_velocities = []
+        joint_efforts = []
+        for name in JOINT_NAMES:
+            joint_id = self._joint_ids[name]
+            actuator_id = self._actuator_ids[name]
+            position_address = self.model.jnt_qposadr[joint_id]
+            velocity_address = self.model.jnt_dofadr[joint_id]
+            joint_positions.append(self.data.qpos[position_address])
+            joint_velocities.append(self.data.qvel[velocity_address])
+            joint_efforts.append(self.data.actuator_force[actuator_id])
+
+        contacts = {
+            foot: self._foot_contact(foot)
+            for foot in FOOT_NAMES
+        }
+        sensors = SensorData(
+            imu=ImuSample(
+                orientation_wxyz=_readonly(orientation),
+                angular_velocity_body=_readonly(
+                    self.data.sensor('imu_gyro').data
+                ),
+                specific_force_body=_readonly(
+                    self.data.sensor('imu_specific_force').data
+                ),
+            ),
+            joint_states=JointStateSample(
+                names=JOINT_NAMES,
+                positions=_readonly(joint_positions),
+                velocities=_readonly(joint_velocities),
+                efforts=_readonly(joint_efforts),
+            ),
+            foot_contacts=MappingProxyType(contacts),
+        )
+        truth = GroundTruth(
+            position_world=_readonly(self.data.xpos[self._base_body_id]),
+            orientation_wxyz=orientation,
+            linear_velocity_body=_readonly(linear_velocity_body),
+            angular_velocity_body=_readonly(angular_velocity_body),
+        )
+        return StepResult(float(self.data.time), sensors, truth)
+
+    def _validate_model(self):
+        names = {
+            self.model.joint(index).name
+            for index in range(self.model.njnt)
+        }
+        missing = set(JOINT_NAMES) - names
+        if missing:
+            raise ValueError(
+                f'MuJoCo model is missing command joints: {sorted(missing)}'
+            )
+        if self.model.nkey < 1:
+            raise ValueError('MuJoCo model must define a safe_stance keyframe')
+
+    def _apply_command(self, command):
+        target_by_name = dict(zip(command.names, command.positions))
+        unknown = set(target_by_name) - set(JOINT_NAMES)
+        if unknown:
+            raise ValueError(f'unknown joint command names: {sorted(unknown)}')
+        for name, value in target_by_name.items():
+            actuator_id = self._actuator_ids[name]
+            low, high = self.model.actuator_ctrlrange[actuator_id]
+            if not low <= value <= high:
+                raise ValueError(
+                    f'joint target {name}={value} outside [{low}, {high}]'
+                )
+            self._targets[JOINT_NAMES.index(name)] = value
+
+    def _write_controls(self):
+        for target, name in zip(self._targets, JOINT_NAMES):
+            self.data.ctrl[self._actuator_ids[name]] = target
+
+    def _foot_contact(self, foot):
+        foot_geom_id = self._foot_geom_ids[foot]
+        site_id = self._foot_site_ids[foot]
+        site_position_world = np.asarray(self.data.site_xpos[site_id])
+        rotation_world_from_foot = np.asarray(
+            self.data.site_xmat[site_id]
+        ).reshape(3, 3)
+        force_world = np.zeros(3)
+        torque_world = np.zeros(3)
+        normal_force = 0.0
+
+        for contact_id in range(self.data.ncon):
+            contact = self.data.contact[contact_id]
+            geom_ids = (contact.geom[0], contact.geom[1])
+            if (
+                foot_geom_id not in geom_ids
+                or self._ground_geom_id not in geom_ids
+            ):
+                continue
+            wrench_contact = np.zeros(6)
+            mujoco.mj_contactForce(
+                self.model,
+                self.data,
+                contact_id,
+                wrench_contact,
+            )
+            rotation_world_from_contact = np.asarray(
+                contact.frame
+            ).reshape(3, 3).T
+            sign_for_foot = 1.0 if contact.geom[1] == foot_geom_id else -1.0
+            contact_force_world = (
+                sign_for_foot
+                * rotation_world_from_contact
+                @ wrench_contact[:3]
+            )
+            contact_torque_world = (
+                sign_for_foot
+                * rotation_world_from_contact
+                @ wrench_contact[3:]
+            )
+            force_world += contact_force_world
+            torque_world += contact_torque_world + np.cross(
+                np.asarray(contact.pos) - site_position_world,
+                contact_force_world,
+            )
+            normal_force += max(0.0, float(wrench_contact[0]))
+
+        return FootContactSample(
+            in_contact=normal_force > 1e-9,
+            normal_force=normal_force,
+            force_foot=_readonly(rotation_world_from_foot.T @ force_world),
+            torque_foot=_readonly(rotation_world_from_foot.T @ torque_world),
+        )
+
+
+def trajectory_fingerprint(results: Sequence[StepResult]):
+    """Flatten stable public fields for deterministic smoke comparisons."""
+    values = []
+    for result in results:
+        values.append(result.time)
+        values.extend(result.sensors.imu.orientation_wxyz)
+        values.extend(result.sensors.imu.angular_velocity_body)
+        values.extend(result.sensors.imu.specific_force_body)
+        values.extend(result.sensors.joint_states.positions)
+        values.extend(result.sensors.joint_states.velocities)
+        values.extend(result.sensors.joint_states.efforts)
+        for foot in FOOT_NAMES:
+            contact = result.sensors.foot_contacts[foot]
+            values.extend((float(contact.in_contact), contact.normal_force))
+            values.extend(contact.force_foot)
+            values.extend(contact.torque_foot)
+        values.extend(result.ground_truth.position_world)
+        values.extend(result.ground_truth.orientation_wxyz)
+        values.extend(result.ground_truth.linear_velocity_body)
+        values.extend(result.ground_truth.angular_velocity_body)
+    return np.asarray(values, dtype=np.float64)

--- a/robot_ws/src/robot_simulation/robot_simulation/mujoco_smoke.py
+++ b/robot_ws/src/robot_simulation/robot_simulation/mujoco_smoke.py
@@ -1,0 +1,54 @@
+"""Run a short headless determinism check for the MuJoCo core."""
+
+from math import sin
+
+import numpy as np
+
+from robot_simulation.mujoco_core import (
+    JOINT_NAMES_BY_LEG,
+    MujocoSimulator,
+    trajectory_fingerprint,
+)
+
+
+def _run_trajectory():
+    simulator = MujocoSimulator()
+    results = [simulator.reset()]
+    for step in range(120):
+        offset = 0.02 * sin(2.0 * np.pi * step / 120.0)
+        command = {
+            joint_name: 0.45 + offset
+            for _hip, joint_name, _calf in JOINT_NAMES_BY_LEG
+        }
+        results.append(simulator.step(command))
+    return results
+
+
+def main():
+    """Require exact repeatability and physically valid teaching signals."""
+    first = _run_trajectory()
+    second = _run_trajectory()
+    first_fingerprint = trajectory_fingerprint(first)
+    second_fingerprint = trajectory_fingerprint(second)
+
+    if not np.array_equal(first_fingerprint, second_fingerprint):
+        raise RuntimeError('MuJoCo trajectories were not exactly repeatable')
+    if not np.all(np.isfinite(first_fingerprint)):
+        raise RuntimeError('MuJoCo trajectory contains non-finite values')
+    contact_samples = [
+        contact.normal_force
+        for result in first
+        for contact in result.sensors.foot_contacts.values()
+    ]
+    if max(contact_samples) <= 0.0:
+        raise RuntimeError(
+            'MuJoCo smoke trajectory never produced foot contact'
+        )
+    print(
+        'MuJoCo smoke test passed: fixed-step reset/step is repeatable, '
+        'mock sensors are finite, and foot forces are nonzero.'
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/robot_ws/src/robot_simulation/setup.py
+++ b/robot_ws/src/robot_simulation/setup.py
@@ -6,8 +6,9 @@ package_name = 'robot_simulation'
 
 setup(
     name=package_name,
-    version='0.1.0',
+    version='0.2.0',
     packages=find_packages(exclude=['test']),
+    package_data={package_name: ['models/*.xml']},
     data_files=[
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),
@@ -18,16 +19,23 @@ setup(
         ('share/' + package_name + '/urdf', glob('urdf/*.trans')),
         ('share/' + package_name + '/urdf/meshes', glob('urdf/meshes/*.stl')),
     ],
-    install_requires=['numpy', 'pybullet', 'scipy', 'setuptools'],
+    install_requires=[
+        'mujoco==3.6.0',
+        'numpy',
+        'pybullet',
+        'scipy',
+        'setuptools',
+    ],
     zip_safe=True,
     maintainer='Mostafa Hussein',
     maintainer_email='mahussein04@gmail.com',
-    description='Deterministic PyBullet simulation and idealized ROS 2 teaching sensors.',
+    description='Deterministic teaching simulators with explicit sensor/truth boundaries.',
     license='NOASSERTION',
     tests_require=['pytest'],
     entry_points={
         'console_scripts': [
             'quad_sim = robot_simulation.pybullet_sim:main',
+            'mujoco_smoke = robot_simulation.mujoco_smoke:main',
             'state_interface_monitor = '
             'robot_simulation.state_interface_monitor:main',
         ],

--- a/robot_ws/src/robot_simulation/test/test_mujoco_core.py
+++ b/robot_ws/src/robot_simulation/test/test_mujoco_core.py
@@ -2,6 +2,7 @@
 
 from dataclasses import fields
 
+import mujoco
 import numpy as np
 import pytest
 
@@ -68,3 +69,45 @@ def test_named_commands_hold_omitted_targets_and_reject_bad_input():
         simulator.step({'Revolute_1': 10.0})
     with pytest.raises(ValueError, match='unique'):
         JointCommand(('Revolute_1', 'Revolute_1'), (0.0, 0.1))
+
+
+def test_rejected_multi_joint_command_does_not_change_next_step():
+    """A late validation failure must not leave an earlier target applied."""
+    simulator = MujocoSimulator(settle_steps=0)
+    reference = MujocoSimulator(settle_steps=0)
+    original_targets = simulator.joint_targets
+
+    with pytest.raises(ValueError, match='outside'):
+        simulator.step({
+            'Revolute_25': 0.50,
+            'Revolute_31': 10.0,
+        })
+
+    assert simulator.joint_targets == original_targets
+    assert np.array_equal(
+        trajectory_fingerprint([simulator.step()]),
+        trajectory_fingerprint([reference.step()]),
+    )
+
+
+def test_rotated_base_angular_velocity_matches_gyro_body_frame():
+    """Free-joint angular qvel is already local, like the gyro reading."""
+    simulator = MujocoSimulator(settle_steps=0)
+    half_angle = np.pi / 4.0
+    simulator.data.qpos[3:7] = (
+        np.cos(half_angle),
+        0.0,
+        0.0,
+        np.sin(half_angle),
+    )
+    simulator.data.qvel[3:6] = (0.3, -0.4, 0.5)
+    mujoco.mj_forward(simulator.model, simulator.data)
+
+    result = simulator.observe()
+
+    assert np.allclose(
+        result.ground_truth.angular_velocity_body,
+        result.sensors.imu.angular_velocity_body,
+        rtol=0.0,
+        atol=1e-12,
+    )

--- a/robot_ws/src/robot_simulation/test/test_mujoco_core.py
+++ b/robot_ws/src/robot_simulation/test/test_mujoco_core.py
@@ -1,0 +1,70 @@
+"""Exercise the ROS-independent deterministic MuJoCo core."""
+
+from dataclasses import fields
+
+import numpy as np
+import pytest
+
+from robot_simulation.mujoco_core import (
+    FOOT_NAMES,
+    GroundTruth,
+    JOINT_NAMES,
+    JointCommand,
+    MujocoSimulator,
+    SensorData,
+    trajectory_fingerprint,
+)
+
+
+def test_reset_and_fixed_trajectory_are_exactly_repeatable():
+    """Reset and replay should produce exactly equal public data."""
+    simulator = MujocoSimulator(settle_steps=80)
+    command = {'Revolute_25': 0.47, 'Revolute_31': 0.47}
+
+    first = [simulator.reset()]
+    first.extend(simulator.step(command) for _ in range(20))
+    second = [simulator.reset()]
+    second.extend(simulator.step(command) for _ in range(20))
+
+    assert np.array_equal(
+        trajectory_fingerprint(first),
+        trajectory_fingerprint(second),
+    )
+    assert first[-1].time == pytest.approx(20 * simulator.timestep)
+
+
+def test_safe_stance_exposes_expected_teaching_interface():
+    """The core should expose mock sensors without embedded truth."""
+    result = MujocoSimulator(settle_steps=120).reset()
+
+    assert result.sensors.joint_states.names == JOINT_NAMES
+    assert tuple(result.sensors.foot_contacts) == FOOT_NAMES
+    assert all(
+        contact.normal_force >= 0.0
+        for contact in result.sensors.foot_contacts.values()
+    )
+    assert np.all(np.isfinite(result.sensors.imu.specific_force_body))
+    assert 'ground_truth' not in {field.name for field in fields(SensorData)}
+    assert {field.name for field in fields(GroundTruth)} == {
+        'position_world',
+        'orientation_wxyz',
+        'linear_velocity_body',
+        'angular_velocity_body',
+    }
+
+
+def test_named_commands_hold_omitted_targets_and_reject_bad_input():
+    """Command updates should be persistent, named, and strictly checked."""
+    simulator = MujocoSimulator(settle_steps=0)
+    original_targets = simulator.joint_targets
+    simulator.step({'Revolute_25': 0.50})
+
+    assert simulator.joint_targets['Revolute_25'] == 0.50
+    for name in set(JOINT_NAMES) - {'Revolute_25'}:
+        assert simulator.joint_targets[name] == original_targets[name]
+    with pytest.raises(ValueError, match='unknown joint'):
+        simulator.step({'not_a_joint': 0.0})
+    with pytest.raises(ValueError, match='outside'):
+        simulator.step({'Revolute_1': 10.0})
+    with pytest.raises(ValueError, match='unique'):
+        JointCommand(('Revolute_1', 'Revolute_1'), (0.0, 0.1))

--- a/scripts/smoke_mujoco.sh
+++ b/scripts/smoke_mujoco.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PYTHON_BIN="python3"
+if [[ -x "${PROJECT_ROOT}/.venv/bin/python" ]]; then
+  PYTHON_BIN="${PROJECT_ROOT}/.venv/bin/python"
+fi
+
+export PYTHONPATH="${PROJECT_ROOT}/robot_ws/src/robot_simulation${PYTHONPATH:+:${PYTHONPATH}}"
+"${PYTHON_BIN}" -m robot_simulation.mujoco_smoke


### PR DESCRIPTION
## Dependency

Depends on #10, which is still open, draft, and unmerged. This PR intentionally targets `codex/reproducible-baseline` so it contains only the Phase 2 delta. Do not merge this PR before #10; after #10 lands, retarget or rebase this PR onto `main` as appropriate.

This branch is synchronized with the latest #10 tip, including its deterministic simulated-time behavior and isolated ground-truth transform wording.

## Summary

- add one documented primitive-only MJCF model with 12 position-controlled joints, four named feet, a conservative safe-stance keyframe, and fixed timestep/solver settings
- add a ROS-independent `MujocoSimulator` core with deterministic `reset()`, one-tick `step(command)`, persistent explicit named-joint targets, and strict command validation
- preserve the experiment-ready teaching boundary with idealized/mock IMU and joint-state samples, per-foot contact flags, summed normal force and local wrench, and a distinct ground-truth object
- add focused reset/command/interface tests plus a headless exact-replay smoke test that compares every public sensor and ground-truth field
- pin MuJoCo 3.6.0, package the MJCF, document limitations and semantics, and add the smoke path to CI

## Review fixes

- preserve MuJoCo free-joint angular qvel directly as body-frame ground truth, matching the gyro convention; a rotated-base regression test prevents a second frame rotation
- validate every name and control range in a multi-joint command before mutating persistent targets; a rejected command is regression-tested against the next deterministic step

## Scope

This is a deterministic teaching core and simplified model, not a physical digital twin, real state estimator, learning environment, or production simulator. It deliberately omits ROS and Gymnasium adapters, rendering, closed-chain recovery, CAD meshes, actuator/sensor imperfections, detailed dynamics validation, and learning algorithms.

## Validation

- focused MuJoCo tests: 5 passed
- `make mujoco-smoke`: exact replay, finite mock sensor data, and nonzero foot forces passed
- ROS 2 Humble `colcon build --symlink-install`: all 3 packages built
- full ROS package test run: 19 tests, 0 errors, 0 failures, 3 existing license checks skipped
- `git diff --check`: passed

GitHub Actions remains the reproducible ROS 2 Jazzy validation target.
